### PR TITLE
Set default code owners to network edge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*                            @hosseinsh @charhate @jtschladen @douglasc-nflx
+*                            @DataDog/network-edge


### PR DESCRIPTION
This PR updates sets the default code owners of this repository to the network edge team. In practice this is a quality of life improvement that will automatically tag our team for a review any time a new PR is submitted.

Closes [EDGE-1361](https://datadoghq.atlassian.net/browse/EDGE-1361).