### PR TITLE
Add many-to-many relationship support between certificates and endpoints

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -45,6 +45,7 @@ from lemur.models import (
     certificate_replacement_associations,
     roles_certificates,
     pending_cert_replacement_associations,
+    EndpointsCertificates,
 )
 from lemur.plugins.base import plugins
 from lemur.policies.models import RotationPolicy
@@ -185,7 +186,12 @@ class Certificate(db.Model):
     )
 
     logs = relationship("Log", backref="certificate")
-    endpoints = relationship("Endpoint", backref="certificate")
+    endpoints_assoc = relationship(
+        "EndpointsCertificates", back_populates="certificate"
+    )
+    endpoints = association_proxy(
+        "endpoints_assoc", "endpoint", creator=lambda ep: EndpointsCertificates(endpoint=ep)
+    )
     rotation_policy = relationship("RotationPolicy")
     sensitive_fields = ("private_key",)
 

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -8,8 +8,8 @@
 """
 import arrow
 from sqlalchemy.orm import relationship
-from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.expression import case
 
@@ -17,7 +17,9 @@ from sqlalchemy_utils import ArrowType
 
 from lemur.database import db
 
-from lemur.models import policies_ciphers
+from lemur.models import policies_ciphers, EndpointsCertificates
+
+from deprecated import deprecated
 
 BAD_CIPHERS = ["Protocol-SSLv3", "Protocol-SSLv2", "Protocol-TLSv1"]
 
@@ -62,8 +64,12 @@ class Endpoint(db.Model):
     port = Column(Integer)
     policy_id = Column(Integer, ForeignKey("policy.id"))
     policy = relationship("Policy", backref="endpoint")
-    certificate_id = Column(Integer, ForeignKey("certificates.id"))
-    certificate_path = Column(String(256))
+    certificates_assoc = relationship(
+        "EndpointsCertificates", back_populates="endpoint"
+    )
+    certificates = association_proxy(
+        "certificates_assoc", "certificate", creator=lambda cert: EndpointsCertificates(certificate=cert)
+    )
     registry_type = Column(String(128))
     source_id = Column(Integer, ForeignKey("sources.id"))
     sensitive = Column(Boolean, default=False)
@@ -72,8 +78,6 @@ class Endpoint(db.Model):
     date_created = Column(
         ArrowType, default=arrow.utcnow, onupdate=arrow.utcnow, nullable=False
     )
-
-    replaced = association_proxy("certificate", "replaced")
 
     @property
     def dns_aliases(self):
@@ -118,6 +122,44 @@ class Endpoint(db.Model):
             )
 
         return issues
+
+    @hybrid_property
+    @deprecated("The certificate attribute is deprecated and will be removed soon.")
+    def certificate(self):
+        """DEPRECATED: Returns the primary certificate associated with the endpoint."""
+        for assoc in self.certificates_assoc:
+            if assoc.primary:
+                return assoc.certificate
+        return None
+
+    @certificate.setter
+    @deprecated("The certificate attribute is deprecated and will be removed soon.")
+    def certificate(self, cert):
+        """DEPRECATED: Sets the primary certificate associated with the endpoint."""
+        for assoc in self.certificates_assoc:
+            if assoc.primary:
+                assoc.certificate = cert
+                return
+        self.certificates_assoc.append(
+            EndpointsCertificates(certificate=cert, endpoint=self, primary=True, path="")
+        )
+
+    @hybrid_property
+    @deprecated("The certificate_path attribute is deprecated and will be removed soon.")
+    def certificate_path(self):
+        """DEPRECATED: Returns the path of the primary certificate associated with the endpoint."""
+        for assoc in self.certificates_assoc:
+            if assoc.primary:
+                return assoc.path
+        return ""
+
+    @certificate_path.setter
+    @deprecated("The certificate_path attribute is deprecated and will be removed soon.")
+    def certificate_path(self, path):
+        for assoc in self.certificates_assoc:
+            if assoc.primary:
+                assoc.path = path
+                return
 
     def __repr__(self):
         return "Endpoint(name={name})".format(name=self.name)

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -139,7 +139,7 @@ class Endpoint(db.Model):
                 assoc.certificate = cert
                 return
         self.certificates_assoc.append(
-            EndpointsCertificates(certificate=cert, endpoint=self, primary=True, path="")
+            EndpointsCertificates(certificate=cert, endpoint=self, primary_certificate=True, path="")
         )
 
     @hybrid_property

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -128,7 +128,7 @@ class Endpoint(db.Model):
     def certificate(self):
         """DEPRECATED: Returns the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
-            if assoc.primary:
+            if assoc.primary_certificate:
                 return assoc.certificate
         return None
 
@@ -137,7 +137,7 @@ class Endpoint(db.Model):
     def certificate(self, cert):
         """DEPRECATED: Sets the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
-            if assoc.primary:
+            if assoc.primary_certificate:
                 assoc.certificate = cert
                 return
         self.certificates_assoc.append(
@@ -149,7 +149,7 @@ class Endpoint(db.Model):
     def certificate_path(self):
         """DEPRECATED: Returns the path of the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
-            if assoc.primary:
+            if assoc.primary_certificate:
                 return assoc.path
         return ""
 
@@ -157,7 +157,7 @@ class Endpoint(db.Model):
     @deprecated("The certificate_path attribute is deprecated and will be removed soon.")
     def certificate_path(self, path):
         for assoc in self.certificates_assoc:
-            if assoc.primary:
+            if assoc.primary_certificate:
                 assoc.path = path
                 return
 

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -155,19 +155,21 @@ class Endpoint(db.Model):
         self.primary_certificate = cert
 
     @hybrid_property
-    @deprecated("The certificate_path attribute is deprecated and will be removed soon. Use Endpoint.primary_certificate.path instead.")
+    @deprecated("The certificate_path attribute is deprecated and will be removed soon. Retrieve from Endpoint.certificates_assoc instead.")
     def certificate_path(self):
         """DEPRECATED: Returns the path of the primary certificate associated with the endpoint."""
-        if self.primary_certificate:
-            return self.primary_certificate.path
+        for assoc in self.certificates_assoc:
+            if assoc.primary:
+                return assoc.path
         return None
 
     @certificate_path.setter
-    @deprecated("The certificate_path attribute is deprecated and will be removed soon. Use Endpoint.primary_certificate.path instead")
+    @deprecated("The certificate_path attribute is deprecated and will be removed soon. Retrieve from Endpoint.certificates_assoc instead.")
     def certificate_path(self, path):
         """DEPRECATED: Sets the path of the primary certificate associated with the endpoint."""
-        if self.primary_certificate:
-            self.primary_certificate = path
+        for assoc in self.certificates_assoc:
+            if assoc.primary:
+                assoc.path = path
 
     def __repr__(self):
         return "Endpoint(name={name})".format(name=self.name)

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -124,18 +124,16 @@ class Endpoint(db.Model):
         return issues
 
     @hybrid_property
-    @deprecated("The certificate attribute is deprecated and will be removed soon.")
-    def certificate(self):
-        """DEPRECATED: Returns the primary certificate associated with the endpoint."""
+    def primary_certificate(self):
+        """Returns the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
             if assoc.primary_certificate:
                 return assoc.certificate
         return None
 
-    @certificate.setter
-    @deprecated("The certificate attribute is deprecated and will be removed soon.")
-    def certificate(self, cert):
-        """DEPRECATED: Sets the primary certificate associated with the endpoint."""
+    @primary_certificate.setter
+    def primary_certificate(self, cert):
+        """Sets the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
             if assoc.primary_certificate:
                 assoc.certificate = cert
@@ -145,21 +143,31 @@ class Endpoint(db.Model):
         )
 
     @hybrid_property
-    @deprecated("The certificate_path attribute is deprecated and will be removed soon.")
+    @deprecated("The certificate attribute is deprecated and will be removed soon. Use Endpoint.primary_certificate instead.")
+    def certificate(self):
+        """DEPRECATED: Returns the primary certificate associated with the endpoint."""
+        return self.primary_certificate
+
+    @certificate.setter
+    @deprecated("The certificate attribute is deprecated and will be removed soon. Use Endpoint.primary_certificate instead.")
+    def certificate(self, cert):
+        """DEPRECATED: Sets the primary certificate associated with the endpoint."""
+        self.primary_certificate = cert
+
+    @hybrid_property
+    @deprecated("The certificate_path attribute is deprecated and will be removed soon. Use Endpoint.primary_certificate.path instead.")
     def certificate_path(self):
         """DEPRECATED: Returns the path of the primary certificate associated with the endpoint."""
-        for assoc in self.certificates_assoc:
-            if assoc.primary_certificate:
-                return assoc.path
-        return ""
+        if self.primary_certificate:
+            return self.primary_certificate.path
+        return None
 
     @certificate_path.setter
-    @deprecated("The certificate_path attribute is deprecated and will be removed soon.")
+    @deprecated("The certificate_path attribute is deprecated and will be removed soon. Use Endpoint.primary_certificate.path instead")
     def certificate_path(self, path):
-        for assoc in self.certificates_assoc:
-            if assoc.primary_certificate:
-                assoc.path = path
-                return
+        """DEPRECATED: Sets the path of the primary certificate associated with the endpoint."""
+        if self.primary_certificate:
+            self.primary_certificate = path
 
     def __repr__(self):
         return "Endpoint(name={name})".format(name=self.name)

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -127,7 +127,7 @@ class Endpoint(db.Model):
     def primary_certificate(self):
         """Returns the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
-            if assoc.primary_certificate:
+            if assoc.primary:
                 return assoc.certificate
         return None
 
@@ -135,11 +135,11 @@ class Endpoint(db.Model):
     def primary_certificate(self, cert):
         """Sets the primary certificate associated with the endpoint."""
         for assoc in self.certificates_assoc:
-            if assoc.primary_certificate:
+            if assoc.primary:
                 assoc.certificate = cert
                 return
         self.certificates_assoc.append(
-            EndpointsCertificates(certificate=cert, endpoint=self, primary_certificate=True, path="")
+            EndpointsCertificates(certificate=cert, endpoint=self, primary=True, path="")
         )
 
     @hybrid_property

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -105,7 +105,7 @@ def get_all_pending_rotation():
     that have been replaced.
     :return:
     """
-    return Endpoint.query.filter(Endpoint.replaced.any()).all()
+    return Endpoint.query.filter(Endpoint.certificate.replaced.any()).all()
 
 
 def create(**kwargs):
@@ -151,7 +151,7 @@ def update(endpoint_id, **kwargs):
     endpoint = database.get(Endpoint, endpoint_id)
 
     endpoint.policy = kwargs["policy"]
-    endpoint.certificate = kwargs["certificate"]
+    endpoint.certificates = kwargs["certificate"]
     endpoint.source = kwargs["source"]
     endpoint.certificate_path = kwargs.get("certificate_path")
     endpoint.registry_type = kwargs.get("registry_type")
@@ -181,7 +181,7 @@ def render(args):
     :return:
     """
     query = database.session_query(Endpoint)\
-        .options(joinedload(Endpoint.certificate))\
+        .options(joinedload(Endpoint.certificates_assoc))\
         .options(joinedload(Endpoint.source))
     filt = args.pop("filter")
 

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -117,8 +117,11 @@ def create(**kwargs):
     aliases = []
     if "aliases" in kwargs:
         aliases = [EndpointDnsAlias(alias=name) for name in kwargs.pop("aliases")]
+    if "certificate" in kwargs:
+        certificate = kwargs.pop("certificate")
     endpoint = Endpoint(**kwargs)
     endpoint.aliases = aliases
+    endpoint.primary_certificate = certificate
     database.create(endpoint)
     metrics.send(
         "endpoint_added", "counter", 1,
@@ -151,9 +154,9 @@ def update(endpoint_id, **kwargs):
     endpoint = database.get(Endpoint, endpoint_id)
 
     endpoint.policy = kwargs["policy"]
-    endpoint.certificates = kwargs["certificate"]
+    endpoint.primary_certificate = kwargs["certificate"]
     endpoint.source = kwargs["source"]
-    endpoint.certificate_path = kwargs.get("certificate_path")
+    endpoint.primary_certificate.path = kwargs.get("certificate_path")
     endpoint.registry_type = kwargs.get("registry_type")
     existing_alias = {}
     for e in endpoint.aliases:

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -23,7 +23,7 @@ def upgrade():
         sa.Column("certificate_id", sa.Integer(), nullable=True),
         sa.Column("endpoint_id", sa.Integer(), nullable=True),
         sa.Column("path", sa.String(length=256), nullable=True),
-        sa.Column("primary_certificate", sa.Boolean(), nullable=False),
+        sa.Column("primary", sa.Boolean(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )
 
@@ -49,8 +49,8 @@ def upgrade():
     op.create_index(
         "unique_primary_certificate_endpoint_ix",
         "endpoints_certificates",
-        ["endpoint_id", "primary_certificate"],
-        postgresql_where=text("primary_certificate"),
+        ["endpoint_id", "primary"],
+        postgresql_where=text("primary"),
         unique=True,
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 
@@ -68,10 +68,10 @@ def upgrade():
             text("select id, certificate_id, certificate_path from endpoints")
     ):
         stmt = text(
-            "insert into endpoints_certificates (endpoint_id, certificate_id, path, primary_certificate) values (:endpoint_id, :certificate_id, :path, :primary_certificate)"
+            "insert into endpoints_certificates (endpoint_id, certificate_id, path, primary) values (:endpoint_id, :certificate_id, :path, :primary)"
         )
         stmt = stmt.bindparams(
-            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, primary_certificate=True
+            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, primary=True
         )
         op.execute(stmt)
 

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -80,6 +80,10 @@ def upgrade():
 
 
 def downgrade():
+    print("Restoring certificate_id and certificate_path columns to endpoints table")
+    op.add_column("endpoints", sa.Column("certificate_id", sa.String(length=256), nullable=True))
+    op.add_column("endpoints", sa.Column("certificate_path", sa.String(length=256), nullable=True))
+
     print("Restoring endpoints_certificate_id_fkey foreign key to endpoints table")
     op.create_foreign_key(
         "endpoints_certificate_id_fkey",
@@ -88,10 +92,6 @@ def downgrade():
         ["certificate_id"],
         ["id"],
     )
-
-    print("Restoring certificate_id and certificate_path columns to endpoints table")
-    op.add_column("endpoints", sa.Column("certificate_id", sa.String(length=256), nullable=True))
-    op.add_column("endpoints", sa.Column("certificate_path", sa.String(length=256), nullable=True))
 
     conn = op.get_bind()
     for certificate_id, endpoint_id, path in conn.execute(

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -81,7 +81,7 @@ def upgrade():
 
 def downgrade():
     print("Restoring certificate_id and certificate_path columns to endpoints table")
-    op.add_column("endpoints", sa.Column("certificate_id", sa.String(length=256), nullable=True))
+    op.add_column("endpoints", sa.Column("certificate_id", sa.Integer(), nullable=True))
     op.add_column("endpoints", sa.Column("certificate_path", sa.String(length=256), nullable=True))
 
     print("Restoring endpoints_certificate_id_fkey foreign key to endpoints table")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -19,15 +19,12 @@ def upgrade():
     print("Creating endpoints_certificates table")
     op.create_table(
         "endpoints_certificates",
-        sa.Column("certificate_id", sa.Integer(), nullable=False),
-        sa.Column("endpoint_id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("certificate_id", sa.Integer(), nullable=True),
+        sa.Column("endpoint_id", sa.Integer(), nullable=True),
         sa.Column("path", sa.String(length=256), nullable=True),
         sa.Column("primary_certificate", sa.Boolean(), nullable=False),
-    )
-    op.create_primary_key(
-        None,
-        "endpoints_certificates",
-        ["certificate_id", "endpoint_id"]
+        sa.PrimaryKeyConstraint("id"),
     )
 
     print("Creating certificate_id_fkey foreign key on endpoints_certificates table")
@@ -37,7 +34,6 @@ def upgrade():
         "certificates",
         ["certificate_id"],
         ["id"],
-        ondelete="CASCADE",
     )
 
     print("Creating endpoint_id_fkey foreign key on endpoints_certificates table")
@@ -47,7 +43,6 @@ def upgrade():
         "endpoints",
         ["endpoint_id"],
         ["id"],
-        ondelete="CASCADE",
     )
 
     print("Creating partial index unique_primary_certificate_ix on endpoints_certificates table")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -1,0 +1,72 @@
+"""Support many-to-many relation between certificates and endpoints
+
+Revision ID: 44d67c1988a2
+Revises: a9987414cf36
+Create Date: 2022-07-20 18:05:10.859504
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '44d67c1988a2'
+down_revision = 'a9987414cf36'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+
+def upgrade():
+    print("Creating endpoints_certificates table")
+    op.create_table(
+        "endpoints_certificates",
+        sa.Column("certificate_id", sa.Integer(), nullable=False),
+        sa.Column("endpoint_id", sa.Integer(), nullable=False),
+        sa.Column("path", sa.String(length=256), nullable=True),
+        sa.Column("primary", sa.Boolean(), nullable=False),
+    )
+    op.create_primary_key(
+        None,
+        "endpoints_certificates",
+        ["certificate_id", "endpoint_id"]
+    )
+
+    print("Creating certificates_id foreign key on endpoints_certificates table")
+    op.create_foreign_key(
+        None,
+        "endpoints_certificates",
+        "certificates",
+        ["certificate_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    print("Creating endpoints_id foreign key on endpoints_certificates table")
+    op.create_foreign_key(
+        None,
+        "endpoints_certificates",
+        "endpoints",
+        ["endpoint_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    print("Populating endpoints_certificates table")
+    conn = op.get_bind()
+    for endpoint_id, certificate_id, certificate_path in conn.execute(
+            text("select id, certificate_id, certificate_path from endpoints")
+    ):
+        stmt = text(
+            "insert into endpoints_certificates (endpoint_id, certificate_id, path, \"primary\") values (:endpoint_id, :certificate_id, :path, :primary)"
+        )
+        stmt = stmt.bindparams(
+            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, primary=True
+        )
+        op.execute(stmt)
+
+
+def downgrade():
+    print("Removing foreign key constraints on endpoints_certificates table")
+    op.drop_constraint(None, "endpoints_certificates", type_="foreignkey")
+
+    print("Removing endpoints_certificates table")
+    op.drop_table("endpoints_certificates")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -55,7 +55,7 @@ def upgrade():
         "unique_primary_certificate_ix",
         "endpoints_certificates",
         ["certificate_id", "endpoint_id", "primary_certificate"],
-        postgresql_where=sa.Text("primary_certificate"),
+        postgresql_where=text("primary_certificate"),
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 
     print("Populating endpoints_certificates table")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -52,7 +52,7 @@ def upgrade():
 
     print("Creating partial index unique_primary_certificate_ix on endpoints_certificates table")
     op.create_index(
-        "unique_primary_certificate_ix",
+        "unique_primary_certificate_endpoint_ix",
         "endpoints_certificates",
         ["endpoint_id", "primary_certificate"],
         postgresql_where=text("primary_certificate"),

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -56,6 +56,7 @@ def upgrade():
         "endpoints_certificates",
         ["endpoint_id", "primary_certificate"],
         postgresql_where=text("primary_certificate"),
+        unique=True,
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 
     print("Populating endpoints_certificates table")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -50,6 +50,14 @@ def upgrade():
         ondelete="CASCADE",
     )
 
+    print("Creating partial index unique_primary_certificate_ix on endpoints_certificates table")
+    op.create_index(
+        "unique_primary_certificate_ix",
+        "endpoints_certificates",
+        ["certificate_id", "endpoint_id", "primary_certificate"],
+        postgresql_where=sa.Text("primary_certificate"),
+    )  # Enforces that only a single primary certificate can be associated with an endpoint.
+
     print("Populating endpoints_certificates table")
     conn = op.get_bind()
     for endpoint_id, certificate_id, certificate_path in conn.execute(

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -30,9 +30,9 @@ def upgrade():
         ["certificate_id", "endpoint_id"]
     )
 
-    print("Creating certificates_id foreign key on endpoints_certificates table")
+    print("Creating certificate_id_fkey foreign key on endpoints_certificates table")
     op.create_foreign_key(
-        None,
+        "certificate_id_fkey",
         "endpoints_certificates",
         "certificates",
         ["certificate_id"],
@@ -40,9 +40,9 @@ def upgrade():
         ondelete="CASCADE",
     )
 
-    print("Creating endpoints_id foreign key on endpoints_certificates table")
+    print("Creating endpoint_id_fkey foreign key on endpoints_certificates table")
     op.create_foreign_key(
-        None,
+        "endpoint_id_fkey",
         "endpoints_certificates",
         "endpoints",
         ["endpoint_id"],
@@ -66,7 +66,8 @@ def upgrade():
 
 def downgrade():
     print("Removing foreign key constraints on endpoints_certificates table")
-    op.drop_constraint(None, "endpoints_certificates", type_="foreignkey")
+    op.drop_constraint("certificate_id_fkey", "endpoints_certificates", type_="foreignkey")
+    op.drop_constraint("endpoint_id_fkey", "endpoints_certificates", type_="foreignkey")
 
     print("Removing endpoints_certificates table")
     op.drop_table("endpoints_certificates")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -54,7 +54,7 @@ def upgrade():
     op.create_index(
         "unique_primary_certificate_ix",
         "endpoints_certificates",
-        ["certificate_id", "endpoint_id", "primary_certificate"],
+        ["endpoint_id", "primary_certificate"],
         postgresql_where=text("primary_certificate"),
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -59,6 +59,14 @@ def upgrade():
         unique=True,
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 
+    print("Creating partial index unique_certificate_endpoint_ix on endpoints_certificates table")
+    op.create_index(
+        "unique_certificate_endpoint_ix",
+        "endpoints_certificates",
+        ["certificate_id", "endpoint_id"],
+        unique=True,
+    )  # Enforces that a given certificate can be associated with an endpoint only once.
+
     print("Populating endpoints_certificates table")
     conn = op.get_bind()
     for endpoint_id, certificate_id, certificate_path in conn.execute(

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -56,10 +56,10 @@ def upgrade():
             text("select id, certificate_id, certificate_path from endpoints")
     ):
         stmt = text(
-            "insert into endpoints_certificates (endpoint_id, certificate_id, path, \"primary\") values (:endpoint_id, :certificate_id, :path, :primary)"
+            "insert into endpoints_certificates (endpoint_id, certificate_id, path, primary_certificate) values (:endpoint_id, :certificate_id, :path, :primary_certificate)"
         )
         stmt = stmt.bindparams(
-            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, primary=True
+            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, primary_certificate=True
         )
         op.execute(stmt)
 

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -97,9 +97,5 @@ def downgrade():
         )
         op.execute(stmt)
 
-    print("Removing foreign key constraints on endpoints_certificates table")
-    op.drop_constraint("certificate_id_fkey", "endpoints_certificates", type_="foreignkey")
-    op.drop_constraint("endpoint_id_fkey", "endpoints_certificates", type_="foreignkey")
-
     print("Removing endpoints_certificates table")
     op.drop_table("endpoints_certificates")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -23,7 +23,7 @@ def upgrade():
         sa.Column("certificate_id", sa.Integer(), nullable=True),
         sa.Column("endpoint_id", sa.Integer(), nullable=True),
         sa.Column("path", sa.String(length=256), nullable=True),
-        sa.Column("primary", sa.Boolean(), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )
 
@@ -49,8 +49,8 @@ def upgrade():
     op.create_index(
         "unique_primary_certificate_endpoint_ix",
         "endpoints_certificates",
-        ["endpoint_id", "primary"],
-        postgresql_where=text("primary"),
+        ["endpoint_id", "is_primary"],
+        postgresql_where=text("is_primary"),
         unique=True,
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 
@@ -68,10 +68,10 @@ def upgrade():
             text("select id, certificate_id, certificate_path from endpoints")
     ):
         stmt = text(
-            "insert into endpoints_certificates (endpoint_id, certificate_id, path, primary) values (:endpoint_id, :certificate_id, :path, :primary)"
+            "insert into endpoints_certificates (endpoint_id, certificate_id, path, is_primary) values (:endpoint_id, :certificate_id, :path, :is_primary)"
         )
         stmt = stmt.bindparams(
-            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, primary=True
+            endpoint_id=endpoint_id, certificate_id=certificate_id, path=certificate_path, is_primary=True
         )
         op.execute(stmt)
 

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -101,7 +101,7 @@ def downgrade():
             "update endpoints set certificate_id = :certificate_id, certificate_path = :certificate_path where id = :endpoint_id"
         )
         stmt = stmt.bindparams(
-            certificate_id=certificate_id, endpoint_id = endpoint_id, certificate_path=certificate_path
+            certificate_id=certificate_id, endpoint_id = endpoint_id, certificate_path=path
         )
         op.execute(stmt)
 

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -22,7 +22,7 @@ def upgrade():
         sa.Column("certificate_id", sa.Integer(), nullable=False),
         sa.Column("endpoint_id", sa.Integer(), nullable=False),
         sa.Column("path", sa.String(length=256), nullable=True),
-        sa.Column("primary", sa.Boolean(), nullable=False),
+        sa.Column("primary_certificate", sa.Boolean(), nullable=False),
     )
     op.create_primary_key(
         None,

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -214,8 +214,8 @@ class EndpointsCertificates(db.Model):
     certificate = relationship("Certificate", back_populates="endpoints_assoc")
     endpoint = relationship("Endpoint", back_populates="certificates_assoc")
 
-    def __init__(self, certificate=None, endpoint=None, primary=True, path=""):
+    def __init__(self, certificate=None, endpoint=None, primary_certificate=True, path=""):
         self.certificate = certificate
         self.endpoint = endpoint
-        self.primary = primary
+        self.primary_certificate = primary_certificate
         self.path = path

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -220,3 +220,18 @@ class EndpointsCertificates(db.Model):
         self.endpoint = endpoint
         self.primary_certificate = primary_certificate
         self.path = path
+
+
+Index(
+    "unique_primary_certificate_endpoint_ix",
+    EndpointsCertificates.endpoint_id,
+    EndpointsCertificates.primary_certificate,
+    unique=True,
+)
+
+Index(
+    "unique_certificate_endpoint_ix",
+    EndpointsCertificates.certificate_id,
+    EndpointsCertificates.endpoint_id,
+    unique=True,
+)

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -211,23 +211,23 @@ class EndpointsCertificates(db.Model):
     certificate_id = Column(ForeignKey("certificates.id"))
     endpoint_id = Column(ForeignKey("endpoints.id"))
     path = Column(String(256))
-    primary_certificate = Column(Boolean, default=True)
+    primary = Column(Boolean, default=True)
     certificate = relationship("Certificate", back_populates="endpoints_assoc")
     endpoint = relationship("Endpoint", back_populates="certificates_assoc")
 
-    def __init__(self, certificate=None, endpoint=None, primary_certificate=True, path=""):
+    def __init__(self, certificate=None, endpoint=None, primary=True, path=""):
         self.certificate = certificate
         self.endpoint = endpoint
-        self.primary_certificate = primary_certificate
+        self.primary = primary
         self.path = path
 
 
 Index(
     "unique_primary_certificate_endpoint_ix",
     EndpointsCertificates.endpoint_id,
-    EndpointsCertificates.primary_certificate,
+    EndpointsCertificates.primary,
     unique=True,
-    postgresql_where=EndpointsCertificates.primary_certificate,
+    postgresql_where=EndpointsCertificates.primary,
 )
 
 Index(

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -227,6 +227,7 @@ Index(
     EndpointsCertificates.endpoint_id,
     EndpointsCertificates.primary_certificate,
     unique=True,
+    postgresql_where=EndpointsCertificates.primary_certificate,
 )
 
 Index(

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -207,8 +207,9 @@ Index(
 
 class EndpointsCertificates(db.Model):
     __tablename__ = "endpoints_certificates"
-    certificate_id = Column(ForeignKey("certificates.id"), primary_key=True)
-    endpoint_id = Column(ForeignKey("endpoints.id"), primary_key=True)
+    id = Column(Integer, primary_key=True)
+    certificate_id = Column(ForeignKey("certificates.id"))
+    endpoint_id = Column(ForeignKey("endpoints.id"))
     path = Column(String(256))
     primary_certificate = Column(Boolean, default=True)
     certificate = relationship("Certificate", back_populates="endpoints_assoc")

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -8,7 +8,8 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
-from sqlalchemy import Column, Integer, ForeignKey, Index, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy import Column, Integer, ForeignKey, Index, UniqueConstraint, String, Boolean
 
 from lemur.database import db
 
@@ -202,3 +203,19 @@ Index(
     pending_cert_role_associations.c.pending_cert_id,
     pending_cert_role_associations.c.role_id,
 )
+
+
+class EndpointsCertificates(db.Model):
+    __tablename__ = "endpoints_certificates"
+    certificate_id = Column(ForeignKey("certificates.id"), primary_key=True)
+    endpoint_id = Column(ForeignKey("endpoints.id"), primary_key=True)
+    path = Column(String(256))
+    primary = Column(Boolean, default=True)
+    certificate = relationship("Certificate", back_populates="endpoints_assoc")
+    endpoint = relationship("Endpoint", back_populates="certificates_assoc")
+
+    def __init__(self, certificate=None, endpoint=None, primary=True, path=""):
+        self.certificate = certificate
+        self.endpoint = endpoint
+        self.primary = primary
+        self.path = path

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -210,7 +210,7 @@ class EndpointsCertificates(db.Model):
     certificate_id = Column(ForeignKey("certificates.id"), primary_key=True)
     endpoint_id = Column(ForeignKey("endpoints.id"), primary_key=True)
     path = Column(String(256))
-    primary = Column(Boolean, default=True)
+    primary_certificate = Column(Boolean, default=True)
     certificate = relationship("Certificate", back_populates="endpoints_assoc")
     endpoint = relationship("Endpoint", back_populates="certificates_assoc")
 

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -211,7 +211,7 @@ class EndpointsCertificates(db.Model):
     certificate_id = Column(ForeignKey("certificates.id"))
     endpoint_id = Column(ForeignKey("endpoints.id"))
     path = Column(String(256))
-    primary = Column(Boolean, default=True)
+    primary = Column("is_primary", Boolean, default=True)
     certificate = relationship("Certificate", back_populates="endpoints_assoc")
     endpoint = relationship("Endpoint", back_populates="certificates_assoc")
 

--- a/lemur/sources/service.py
+++ b/lemur/sources/service.py
@@ -107,6 +107,7 @@ def sync_endpoints(source):
 
         certificate_name = endpoint.pop("certificate_name")
 
+        # TODO(EDGE-1363) - Update source plugin(s) to sync SNI certificates
         endpoint["certificate"] = certificate_service.get_by_name(certificate_name)
 
         # if get cert by name failed, we attempt a search via serial number and hash comparison

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -1,12 +1,11 @@
 import json
 from datetime import date
 
-from factory import Sequence, post_generation, SubFactory, List
+from factory import Sequence, post_generation, SubFactory
 from factory.alchemy import SQLAlchemyModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText, FuzzyDate, FuzzyInteger
 
 from lemur.database import db
-from lemur.models import EndpointsCertificates
 from lemur.authorities.models import Authority
 from lemur.certificates.models import Certificate
 from lemur.destinations.models import Destination
@@ -57,6 +56,7 @@ class RotationPolicyFactory(BaseFactory):
 class CertificateFactory(BaseFactory):
     """Certificate factory."""
 
+    id = Sequence(lambda n: n)
     name = Sequence(lambda n: "certificate{0}".format(n))
     chain = INTERMEDIATE_CERT_STR
     body = SAN_CERT_STR
@@ -313,21 +313,10 @@ class PolicyFactory(BaseFactory):
         model = Policy
 
 
-class EndpointsCertificatesFactory(BaseFactory):
-    """EndpointsCertificates Association Factory."""
-
-    primary_certificate = True
-    certificate = SubFactory(CertificateFactory)
-
-    class Meta:
-        """Factory Configuration."""
-
-        model = EndpointsCertificates
-
-
 class EndpointFactory(BaseFactory):
     """Endpoint Factory."""
 
+    #id = Sequence(lambda n: n)
     owner = "joe@example.com"
     name = Sequence(lambda n: "endpoint{0}".format(n))
     type = FuzzyChoice(["elb"])
@@ -335,16 +324,12 @@ class EndpointFactory(BaseFactory):
     port = FuzzyInteger(0, high=65535)
     dnsname = "endpoint.example.com"
     policy = SubFactory(PolicyFactory)
-    certificates_assoc = List([SubFactory(EndpointsCertificatesFactory)])
     source = SubFactory(SourceFactory)
 
     class Meta:
         """Factory Configuration."""
 
         model = Endpoint
-
-
-EndpointsCertificatesFactory.endpoint = SubFactory(EndpointFactory)
 
 
 class ApiKeyFactory(BaseFactory):

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -56,7 +56,6 @@ class RotationPolicyFactory(BaseFactory):
 class CertificateFactory(BaseFactory):
     """Certificate factory."""
 
-    id = Sequence(lambda n: n)
     name = Sequence(lambda n: "certificate{0}".format(n))
     chain = INTERMEDIATE_CERT_STR
     body = SAN_CERT_STR
@@ -316,7 +315,6 @@ class PolicyFactory(BaseFactory):
 class EndpointFactory(BaseFactory):
     """Endpoint Factory."""
 
-    #id = Sequence(lambda n: n)
     owner = "joe@example.com"
     name = Sequence(lambda n: "endpoint{0}".format(n))
     type = FuzzyChoice(["elb"])

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -1,11 +1,12 @@
 import json
 from datetime import date
 
-from factory import Sequence, post_generation, SubFactory
+from factory import Sequence, post_generation, SubFactory, List
 from factory.alchemy import SQLAlchemyModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText, FuzzyDate, FuzzyInteger
 
 from lemur.database import db
+from lemur.models import EndpointsCertificates
 from lemur.authorities.models import Authority
 from lemur.certificates.models import Certificate
 from lemur.destinations.models import Destination
@@ -312,6 +313,18 @@ class PolicyFactory(BaseFactory):
         model = Policy
 
 
+class EndpointsCertificatesFactory(BaseFactory):
+    """EndpointsCertificates Association Factory."""
+
+    primary = True
+    certificate = SubFactory(CertificateFactory)
+
+    class Meta:
+        """Factory Configuration."""
+
+        model = EndpointsCertificates
+
+
 class EndpointFactory(BaseFactory):
     """Endpoint Factory."""
 
@@ -322,13 +335,16 @@ class EndpointFactory(BaseFactory):
     port = FuzzyInteger(0, high=65535)
     dnsname = "endpoint.example.com"
     policy = SubFactory(PolicyFactory)
-    certificate = SubFactory(CertificateFactory)
+    certificates_assoc = List([SubFactory(EndpointsCertificatesFactory)])
     source = SubFactory(SourceFactory)
 
     class Meta:
         """Factory Configuration."""
 
         model = Endpoint
+
+
+EndpointsCertificatesFactory.endpoint = SubFactory(EndpointFactory)
 
 
 class ApiKeyFactory(BaseFactory):

--- a/lemur/tests/factories.py
+++ b/lemur/tests/factories.py
@@ -316,7 +316,7 @@ class PolicyFactory(BaseFactory):
 class EndpointsCertificatesFactory(BaseFactory):
     """EndpointsCertificates Association Factory."""
 
-    primary = True
+    primary_certificate = True
     certificate = SubFactory(CertificateFactory)
 
     class Meta:

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -94,10 +94,12 @@ def test_get_by_serial(session, certificate):
 def test_get_all_certs_attached_to_endpoint_without_autorotate(session):
     from lemur.certificates.service import get_all_certs_attached_to_endpoint_without_autorotate, \
         cleanup_after_revoke
-    from lemur.tests.factories import EndpointFactory
+    from lemur.tests.factories import CertificateFactory, EndpointFactory
 
     # add a certificate with endpoint
-    EndpointFactory()
+    ep = EndpointFactory()
+    crt = CertificateFactory()
+    ep.primary_certificate = crt
 
     list_before = get_all_certs_attached_to_endpoint_without_autorotate()
     len_list_before = len(list_before)

--- a/lemur/tests/test_endpoints_certificates_assoc.py
+++ b/lemur/tests/test_endpoints_certificates_assoc.py
@@ -1,9 +1,10 @@
+import pytest
 import uuid
 from lemur import database
 from lemur.certificates import service as certificate_service
 from lemur.endpoints import service as endpoint_service
 from lemur.models import EndpointsCertificates
-from lemur.tests.factories import AuthorityFactory, CertificateFactory, UserFactory, SourceFactory
+from lemur.tests.factories import AuthorityFactory, CertificateFactory, EndpointFactory, UserFactory, SourceFactory
 from lemur.tests.vectors import (
     CSR_STR,
 )
@@ -54,3 +55,34 @@ def test_secondary_certificates_assoc():
 
     actual_endpoint = endpoint_service.get_by_name(expected_endpoint.name)
     assert expected_endpoint == actual_endpoint
+
+def test_primary_certificate_uniqueness(session):
+    """Ensure that only one primary certificate can be associated with an endpoint."""
+    # Create and associate two primary certificates with an endpoint
+    endpoint = endpoint_service.create(name=_fake_name(), certificate=_fake_cert(), source=SourceFactory())
+
+    # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
+    endpoint.certificates_assoc.append(
+        EndpointsCertificates(certificate=_fake_cert(), endpoint=endpoint, primary_certificate=True)
+    )
+
+    with pytest.raises(Exception):
+        session.commit()
+
+
+def test_certificate_uniqueness(session):
+    """Ensure that a given certificate can only be associated with an endpoint once."""
+    # Create and associate primary certificate with an endpoint
+    crt = CertificateFactory()
+    endpoint = EndpointFactory()
+    endpoint.primary_certificate = crt
+
+    # Associate the same secondary certificate with the endpoint twice
+    for _ in range(0, 2):
+        # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
+        endpoint.certificates_assoc.append(
+            EndpointsCertificates(certificate=crt, endpoint=endpoint, primary_certificate=False)
+        )
+
+    with pytest.raises(Exception):
+        session.commit()

--- a/lemur/tests/test_endpoints_certificates_assoc.py
+++ b/lemur/tests/test_endpoints_certificates_assoc.py
@@ -31,7 +31,7 @@ def test_secondary_certificates_assoc(session):
     for crt in additional_certs:
         # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
         expected_endpoint.certificates_assoc.append(
-            EndpointsCertificates(certificate=crt, endpoint=expected_endpoint, primary_certificate=False)
+            EndpointsCertificates(certificate=crt, endpoint=expected_endpoint, primary=False)
         )
 
     actual_endpoint = session.query(Endpoint).filter(Endpoint.name == expected_endpoint.name).scalar()
@@ -47,7 +47,7 @@ def test_primary_certificate_uniqueness(session):
 
     # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
     endpoint.certificates_assoc.append(
-        EndpointsCertificates(certificate=CertificateFactory(), endpoint=endpoint, primary_certificate=True)
+        EndpointsCertificates(certificate=CertificateFactory(), endpoint=endpoint, primary=True)
     )
 
     with pytest.raises(Exception):
@@ -65,7 +65,7 @@ def test_certificate_uniqueness(session):
     for _ in range(0, 2):
         # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
         endpoint.certificates_assoc.append(
-            EndpointsCertificates(certificate=crt, endpoint=endpoint, primary_certificate=False)
+            EndpointsCertificates(certificate=crt, endpoint=endpoint, primary=False)
         )
 
     with pytest.raises(Exception):

--- a/lemur/tests/test_endpoints_certificates_assoc.py
+++ b/lemur/tests/test_endpoints_certificates_assoc.py
@@ -1,0 +1,56 @@
+import uuid
+from lemur import database
+from lemur.certificates import service as certificate_service
+from lemur.endpoints import service as endpoint_service
+from lemur.models import EndpointsCertificates
+from lemur.tests.factories import AuthorityFactory, CertificateFactory, UserFactory, SourceFactory
+from lemur.tests.vectors import (
+    CSR_STR,
+)
+
+
+def _fake_name():
+    return uuid.uuid4().hex
+
+
+def _fake_cert():
+    return certificate_service.create(
+        authority=AuthorityFactory(),
+        name=_fake_name(),
+        csr=CSR_STR,
+        creator=UserFactory(),
+        owner="foo@example.com",
+    )
+
+
+def test_primary_certificate_assoc():
+    """Ensure that a primary certificate can be associated with an endpoint."""
+    # Create and associate primary certificate with an endpoint
+    crt = _fake_cert()
+
+    expected_endpoint = endpoint_service.create(name=_fake_name(), certificate=crt, source=SourceFactory())
+
+    actual_endpoint = endpoint_service.get_by_name(expected_endpoint.name)
+    assert expected_endpoint == actual_endpoint
+    assert actual_endpoint.primary_certificate == crt
+
+
+def test_secondary_certificates_assoc():
+    """Ensure that secondary certificates can be associated with an endpoint."""
+    # Create and associate primary certificate with an endpoint
+    crt = _fake_cert()
+
+    expected_endpoint = endpoint_service.create(name=_fake_name(), certificate=crt, source=SourceFactory())
+
+    # Create and associate secondary certificates with endpoint
+    additional_certs = [CertificateFactory() for _ in range(0, 5)]
+
+    # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
+    for crt in additional_certs:
+        expected_endpoint.certificates_assoc.append(
+            EndpointsCertificates(certificate=crt, endpoint=expected_endpoint, primary_certificate=False)
+        )
+    database.update(expected_endpoint)
+
+    actual_endpoint = endpoint_service.get_by_name(expected_endpoint.name)
+    assert expected_endpoint == actual_endpoint

--- a/lemur/tests/test_endpoints_certificates_assoc.py
+++ b/lemur/tests/test_endpoints_certificates_assoc.py
@@ -54,6 +54,16 @@ def test_primary_certificate_uniqueness(session):
         session.commit()
 
 
+def test_certificate_path(session):
+    crt = CertificateFactory()
+    fake_path = "/fake/path"
+    endpoint = EndpointFactory()
+    endpoint.primary_certificate = crt
+    endpoint.certificate_path = fake_path
+
+    assert endpoint.certificate_path == fake_path
+
+
 def test_certificate_uniqueness(session):
     """Ensure that a given certificate can only be associated with an endpoint once."""
     # Create and associate primary certificate with an endpoint


### PR DESCRIPTION
This PR introduces the database schema changes required to support modeling the following relationships:

1. many certificates to an endpoint (**_new requirement for adding SNI support_**)
2. many endpoints to a certificate (**_already supported today_**). 

To achieve this relationship, I used the recommend [Association Object](https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#association-object) and [Association Proxy](https://docs.sqlalchemy.org/en/14/orm/extensions/associationproxy.html) patterns described in the official SQLAlchemy documentation. I maintained backward compatibility at existing call sites using [Hybrid Attributes](https://docs.sqlalchemy.org/en/14/orm/extensions/hybrid.html) but added deprecation warnings to notify the users that these should be updated accordingly.

The changes introduced in this PR unblock the further work required to add SNI certificate rotation support to Lemur and closes [EDGE-1362](https://datadoghq.atlassian.net/browse/EDGE-1362).

**Testing Strategy**
- Rely on existing unit tests to detect regressions and new unit tests to verify new features work correctly.
- Deploy to sandbox environment and run several manual source syncs and certificate rotation operations and verify through inspection that the Lemur state is correct.
- If a rollback is needed, we can [restore from backup](https://datadoghq.atlassian.net/wiki/spaces/NE/pages/2329149651/Restore+From+a+Backup) or downgrade the schema to a previous version using the `lemur db migrate` utility without data loss.