### PR TITLE
Only build prod image for tagged commits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,8 @@ build-stage-image:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
   script:
     - cd publish && docker buildx build --label target=staging --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA} --tag registry.ddbuild.io/ci/lemur:v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA --push .
+  except:
+    - tags
 
 # build a prod image when we create a new tag
 build-prod-image:


### PR DESCRIPTION
While testing the CI image build process I noticed that two Lemur images were being published: one with the `staging` label, and another with the `prod` label. In this particular scenario where a commit is tagged we only need to publish a single image with the `prod` label. To achieve this the `build-stage-image` stage in the CI has been explicitly disabled for tagged commits.