### PR TITLE
Support displaying SNI certificates to user in web UI

### DIFF
--- a/lemur/endpoints/schemas.py
+++ b/lemur/endpoints/schemas.py
@@ -25,6 +25,13 @@ class PolicyNestedOutputSchema(LemurOutputSchema):
     ciphers = fields.Nested(CipherNestedOutputSchema, many=True)
 
 
+class EndpointCertificateOutputSchema(LemurOutputSchema):
+    __envelope__ = False
+    primary = fields.Boolean()
+    path = fields.String()
+    certificate = fields.Nested(CertificateNestedOutputSchema)
+
+
 class EndpointOutputSchema(LemurOutputSchema):
     id = fields.Integer()
     description = fields.String()
@@ -36,8 +43,7 @@ class EndpointOutputSchema(LemurOutputSchema):
     type = fields.String()
     port = fields.Integer()
     active = fields.Boolean()
-    certificate = fields.Nested(CertificateNestedOutputSchema)
-    certificate_path = fields.String()
+    certificates = fields.Nested(EndpointCertificateOutputSchema, many=True, attribute="certificates_assoc")
     registry_type = fields.String()
     policy = fields.Nested(PolicyNestedOutputSchema)
 

--- a/lemur/static/app/angular/endpoints/view/view.tpl.html
+++ b/lemur/static/app/angular/endpoints/view/view.tpl.html
@@ -49,29 +49,38 @@
                         <td colspan="12">
                             <uib-tabset justified="true" class="col-md-6">
                                 <uib-tab>
-                                    <uib-tab-heading>Certificate</uib-tab-heading>
+                                    <uib-tab-heading>Certificate(s)</uib-tab-heading>
                                     <ul class="list-group">
-                                        <li class="list-group-item">
-                                            <strong>Name</strong>
-                                            <span class="pull-right">
-                                                {{ endpoint.certificate.name }}
-                                            </span>
-                                        </li>
-                                        <li class="list-group-item">
-                                            <strong>Not Before</strong>
-                                        <span class="pull-right" uib-tooltip="{{ endpoint.certificate.notBefore }}">
-                                          {{ momentService.createMoment(endpoint.certificate.notBefore) }}
-                                        </span>
-                                        </li>
-                                        <li class="list-group-item">
-                                            <strong>Not After</strong>
-                                            <span class="pull-right" uib-tooltip="{{ endpoint.certificate.notAfter }}">
-                                              {{ momentService.createMoment(endpoint.certificate.notAfter) }}
-                                            </span>
-                                        </li>
-                                        <li class="list-group-item">
-                                            <strong>Description</strong>
-                                            <p>{{ endpoint.certificate.description }}</p>
+                                        <li ng-repeat="item in endpoint.certificates | orderBy: '-primary'" class="list-group-item">
+                                            <ul class="list-group">
+                                                <li class="list-group-item">
+                                                    <strong>Name</strong>
+                                                    <span class="pull-right">
+                                                        {{ item.certificate.name }}
+                                                    </span>
+                                                </li>
+                                                <li class="list-group-item">
+                                                    <strong>Not Before</strong>
+                                                <span class="pull-right" uib-tooltip="{{ item.certificate.notBefore }}">
+                                                  {{ momentService.createMoment(item.certificate.notBefore) }}
+                                                </span>
+                                                </li>
+                                                <li class="list-group-item">
+                                                    <strong>Not After</strong>
+                                                    <span class="pull-right" uib-tooltip="{{ item.certificate.notAfter }}">
+                                                      {{ momentService.createMoment(item.certificate.notAfter) }}
+                                                    </span>
+                                                </li>
+                                                <li class="list-group-item">
+                                                    <strong>Attachment Type</strong>
+                                                    <span ng-if="item.primary" uib-tooltip="Default certificate used to serve requests" uib-tooltip-placement="right" class="label label-primary pull-right">Primary</span>
+                                                    <span ng-if="!item.primary" uib-tooltip="Certificate used to serve requests for multiple domains on the same port via SNI" uib-tooltip-placement="right" class="label label-default pull-right">SNI</span>
+                                                </li>
+                                                <li class="list-group-item">
+                                                    <strong>Description</strong>
+                                                    <p>{{ item.certificate.description }}</p>
+                                                </li>
+                                            </ul>
                                         </li>
                                     </ul>
                                 </uib-tab>


### PR DESCRIPTION
This PR makes the following high level changes to support displaying all of the certificates attached to an endpoint in the web UI:

1. Updates the endpoints REST API routes so that they return all certificates attached to the endpoint in their JSON response.
2. Updates the angular application to render all certificates attached to the endpoint in the web UI using a nested [list group](https://getbootstrap.com/docs/4.0/components/list-group/). 

**Preview**

![sni-ui-changes-preview](https://user-images.githubusercontent.com/5983714/183480136-77cc465c-7375-4af4-897b-a867ac7c648a.png)

Closes [EDGE-1363](https://datadoghq.atlassian.net/browse/EDGE-1364). Requires #5.