### PR TITLE
Adjust uniqueness constraints and deletion behavior for endpoints and certificates

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -187,7 +187,7 @@ class Certificate(db.Model):
 
     logs = relationship("Log", backref="certificate")
     endpoints_assoc = relationship(
-        "EndpointsCertificates", back_populates="certificate"
+        "EndpointsCertificates", back_populates="certificate", cascade="all, delete-orphan"
     )
     endpoints = association_proxy(
         "endpoints_assoc", "endpoint", creator=lambda ep: EndpointsCertificates(endpoint=ep)

--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -65,7 +65,7 @@ class Endpoint(db.Model):
     policy_id = Column(Integer, ForeignKey("policy.id"))
     policy = relationship("Policy", backref="endpoint")
     certificates_assoc = relationship(
-        "EndpointsCertificates", back_populates="endpoint"
+        "EndpointsCertificates", back_populates="endpoint", cascade="all, delete-orphan"
     )
     certificates = association_proxy(
         "certificates_assoc", "certificate", creator=lambda cert: EndpointsCertificates(certificate=cert)

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -34,6 +34,7 @@ def upgrade():
         "certificates",
         ["certificate_id"],
         ["id"],
+        ondelete="cascade"
     )
 
     print("Creating endpoint_id_fkey foreign key on endpoints_certificates table")
@@ -43,6 +44,7 @@ def upgrade():
         "endpoints",
         ["endpoint_id"],
         ["id"],
+        ondelete="cascade"
     )
 
     print("Creating partial index unique_primary_certificate_ix on endpoints_certificates table")

--- a/lemur/migrations/versions/44d67c1988a2_.py
+++ b/lemur/migrations/versions/44d67c1988a2_.py
@@ -56,14 +56,6 @@ def upgrade():
         unique=True,
     )  # Enforces that only a single primary certificate can be associated with an endpoint.
 
-    print("Creating partial index unique_certificate_endpoint_ix on endpoints_certificates table")
-    op.create_index(
-        "unique_certificate_endpoint_ix",
-        "endpoints_certificates",
-        ["certificate_id", "endpoint_id"],
-        unique=True,
-    )  # Enforces that a given certificate can be associated with an endpoint only once.
-
     print("Populating endpoints_certificates table")
     conn = op.get_bind()
     for endpoint_id, certificate_id, certificate_path in conn.execute(

--- a/lemur/models.py
+++ b/lemur/models.py
@@ -229,10 +229,3 @@ Index(
     unique=True,
     postgresql_where=EndpointsCertificates.primary,
 )
-
-Index(
-    "unique_certificate_endpoint_ix",
-    EndpointsCertificates.certificate_id,
-    EndpointsCertificates.endpoint_id,
-    unique=True,
-)

--- a/lemur/tests/test_endpoints_certificates_assoc.py
+++ b/lemur/tests/test_endpoints_certificates_assoc.py
@@ -2,6 +2,7 @@ import pytest
 from lemur.endpoints.models import Endpoint
 from lemur.models import EndpointsCertificates
 from lemur.tests.factories import CertificateFactory, EndpointFactory
+from sqlalchemy.exc import SQLAlchemyError
 
 
 def test_primary_certificate_assoc(session):
@@ -65,18 +66,18 @@ def test_certificate_path(session):
 
 
 def test_certificate_uniqueness(session):
-    """Ensure that a given certificate can only be associated with an endpoint once."""
+    """Ensure that a given SNI certificate can be associated with an endpoint more than once."""
     # Create and associate primary certificate with an endpoint
-    crt = CertificateFactory()
     endpoint = EndpointFactory()
-    endpoint.primary_certificate = crt
+    endpoint.primary_certificate = CertificateFactory()
 
-    # Associate the same secondary certificate with the endpoint twice
-    for _ in range(0, 2):
-        # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
-        endpoint.certificates_assoc.append(
-            EndpointsCertificates(certificate=crt, endpoint=endpoint, primary=False)
-        )
-
-    with pytest.raises(Exception):
-        session.commit()
+    # Associate a SNI certificate with the endpoint twice
+    try:
+        crt = CertificateFactory()
+        for _ in range(0, 2):
+            # TODO(EDGE-1363) Expose API for managing secondary certificates associated with an endpoint
+            endpoint.certificates_assoc.append(
+                EndpointsCertificates(certificate=crt, endpoint=endpoint, primary=False)
+            )
+    except SQLAlchemyError:
+        assert False


### PR DESCRIPTION
- Remove the unique constraint which enforces that a given SNI certificate can be associated with an endpoint only once. In AWS for example, it's possible for the same certificate to be associated with an ELBv2 many times. While this is unusual, we should still allow this state to be modeled in the database so it can be handled properly elsewhere. (E.g. a background task which removes unnecessary duplicate certificate attachments.)
- Update the foreign key constraints added in #5 to use cascade deletion behavior. This gives very strong guarantees that when a `Certificate` or `Endpoint` is deleted from the database, the corresponding `EndpointsCertificates` association object will be deleted as well.
- Use `cascade='all,delete-orphan'` on the ORM relationships added in #5. This is required to ensure that any `EndpointsCertificates` association object is deleted from the database when de-associating a `Certificate` from an `Endpoint` (without deleting the `Endpoint` itself) for example.