### PR TITLE
Fix query used for retrieving endpoints pending rotation

### DIFF
--- a/lemur/certificates/cli.py
+++ b/lemur/certificates/cli.py
@@ -302,7 +302,9 @@ def rotate(endpoint_name, source, new_certificate_name, old_certificate_name, me
             # which are associated with a certificate that has been replaced
             print("[+] Rotating all endpoints that have new certificates available")
             for endpoint in endpoint_service.get_all_pending_rotation():
-
+                if not endpoint.certificate.replaced:
+                    # TODO(EDGE-1365) Support rotating SNI certificates.
+                    continue
                 log_data["message"] = "Rotating endpoint from old to new cert"
                 if len(endpoint.certificate.replaced) > 1:
                     log_data["message"] = f"Multiple replacement certificates found, going with the first one out of " \
@@ -444,6 +446,9 @@ def rotate_region(endpoint_name, new_certificate_name, old_certificate_name, mes
             current_app.logger.info(log_data)
             all_pending_rotation_endpoints = endpoint_service.get_all_pending_rotation()
             for endpoint in all_pending_rotation_endpoints:
+                if not endpoint.certificate.replaced:
+                    # TODO(EDGE-1365) Support rotating SNI certificates.
+                    continue
                 log_data["endpoint"] = endpoint.dnsname
                 if region not in endpoint.dnsname:
                     log_data["message"] = "Skipping rotation, region mismatch"

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import joinedload
 
 from lemur import database
 from lemur.common.utils import truthiness
+from lemur.certificates.models import Certificate
 from lemur.endpoints.models import Endpoint, EndpointDnsAlias, Policy, Cipher
 from lemur.sources.models import Source
 from lemur.extensions import metrics
@@ -105,7 +106,7 @@ def get_all_pending_rotation():
     that have been replaced.
     :return:
     """
-    return Endpoint.query.filter(Endpoint.certificate.replaced.any()).all()
+    return Endpoint.query.filter(Endpoint.certificates.any(Certificate.replaced.any())).all()
 
 
 def create(**kwargs):

--- a/lemur/tests/test_endpoints.py
+++ b/lemur/tests/test_endpoints.py
@@ -28,6 +28,17 @@ def test_get_by_name_and_source(client, source_plugin):
     assert endpoint == get_by_name_and_source(endpoint.name, endpoint.source.label)
 
 
+def test_get_all_pending_rotation(client, source_plugin):
+    from lemur.endpoints.service import get_all_pending_rotation
+
+    endpoint = EndpointFactory()
+    endpoint.certificate = CertificateFactory()
+    new_certificate = CertificateFactory()
+    endpoint.certificate.replaced = [new_certificate]
+
+    assert [endpoint] == get_all_pending_rotation()
+
+
 @pytest.mark.parametrize(
     "token,status",
     [


### PR DESCRIPTION
The existing query used for fetching endpoints with certificates eligible for rotation is currently throwing an exception and failing:
```python3
>>> Endpoint.query.filter(Endpoint.primary_certificate.replaced.any()).all()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/ext/hybrid.py", line 898, in __get__
    return self._expr_comparator(owner)
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/ext/hybrid.py", line 1105, in expr_comparator
    comparator(owner),
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/ext/hybrid.py", line 1090, in _expr
    return ExprComparator(cls, expr(cls), self)
  File "/opt/lemur/lemur/endpoints/models.py", line 129, in primary_certificate
    for assoc in self.certificates_assoc:
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/sql/operators.py", line 432, in __getitem__
    return self.operate(getitem, index)
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 226, in operate
    return op(self.comparator, *other, **kwargs)
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/sql/operators.py", line 432, in __getitem__
    return self.operate(getitem, index)
  File "/opt/venv/lib/python3.8/site-packages/sqlalchemy/sql/operators.py", line 230, in operate
    raise NotImplementedError(str(op))
NotImplementedError: <built-in function getitem>
```

The reason this is occurring is because `certificate` was changed to a hybrid attribute in https://github.com/DataDog/lemur/pull/5.

This PR fixes the issue by updating the query filter to use the new `certificates` relationship added in https://github.com/DataDog/lemur/pull/5. This will also be used for determining which endpoints have SNI certificates eligible for rotation in https://github.com/DataDog/lemur/pull/11.

```python
>>> Endpoint.query.filter(Endpoint.certificates.any(Certificate.replaced.any())).all()
[Endpoint(name=lb-lemur-testing)]
```