### PR TITLE
Fix update method in endpoints controller

### DIFF
--- a/lemur/endpoints/models.py
+++ b/lemur/endpoints/models.py
@@ -150,7 +150,7 @@ class Endpoint(db.Model):
     @sni_certificates.setter
     def sni_certificates(self, certs):
         """Sets the SNI certificates associated with the endpoint."""
-        self.certificates_assoc = [assoc for assoc in self.certificates_assoc if not assoc.primary]
+        self.certificates_assoc = [assoc for assoc in self.certificates_assoc if assoc.primary]
         for cert in certs:
             self.add_sni_certificate(cert)
 

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -163,7 +163,7 @@ def update(endpoint_id, **kwargs):
 
     if primary_certificate:
         endpoint.primary_certificate = primary_certificate
-        endpoint.set_certificate_path(certificate=endpoint.primary_certificate, path=primary_certificate["path"])
+        endpoint.set_certificate_path(certificate=endpoint.primary_certificate["certificate"], path=primary_certificate["path"])
     for crt in sni_certificates:
         endpoint.sni_certificates = []
         endpoint.add_sni_certificate(crt["certificate"], crt["path"])

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -162,8 +162,8 @@ def update(endpoint_id, **kwargs):
     sni_certificates = kwargs.pop("sni_certificates", [])
 
     if primary_certificate:
-        endpoint.primary_certificate = primary_certificate
-        endpoint.set_certificate_path(certificate=endpoint.primary_certificate["certificate"], path=primary_certificate["path"])
+        endpoint.primary_certificate = primary_certificate["certificate"]
+        endpoint.set_certificate_path(certificate=endpoint.primary_certificate, path=primary_certificate["path"])
     for crt in sni_certificates:
         endpoint.sni_certificates = []
         endpoint.add_sni_certificate(crt["certificate"], crt["path"])

--- a/lemur/endpoints/service.py
+++ b/lemur/endpoints/service.py
@@ -164,8 +164,8 @@ def update(endpoint_id, **kwargs):
     if primary_certificate:
         endpoint.primary_certificate = primary_certificate["certificate"]
         endpoint.set_certificate_path(certificate=endpoint.primary_certificate, path=primary_certificate["path"])
+    endpoint.sni_certificates = []
     for crt in sni_certificates:
-        endpoint.sni_certificates = []
         endpoint.add_sni_certificate(crt["certificate"], crt["path"])
 
     endpoint.policy = kwargs["policy"]

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -45,7 +45,7 @@ def test_sync_endpoints(session):
     from unittest import mock
     from lemur.endpoints import service as endpoint_service
     from lemur.sources import service as source_service
-    from lemur.tests.factories import SourceFactory, CertificateFactory
+    from lemur.tests.factories import EndpointFactory, SourceFactory, CertificateFactory
     from lemur.plugins.lemur_aws.plugin import AWSSourcePlugin
 
     source = SourceFactory()
@@ -53,6 +53,8 @@ def test_sync_endpoints(session):
 
     crt1 = CertificateFactory()
     crt2 = CertificateFactory()
+    existing_endpoint = EndpointFactory(name="test-lb-4", dnsname="test4.example.com")
+    existing_endpoint.primary_certificate = crt1
     session.commit()
 
     with mock.patch.object(
@@ -116,13 +118,30 @@ def test_sync_endpoints(session):
                     )
                 ],
                 registry_type="iam",
+            ),
+            dict(
+                name="test-lb-4",
+                dnsname="test4.example.com",
+                type="elbv2",
+                port=443,
+                policy=dict(
+                    name="none",
+                    ciphers=[],
+                ),
+                primary_certificate=dict(
+                    name=crt2.name,
+                    path="/fakecrt2",
+                    registry_type="iam",
+                ),
+                sni_certificates=[],
+                registry_type="iam",
             )
         ],
     ):
         new, updated, updated_by_hash = source_service.sync_endpoints(source)
 
     assert new == 3
-    assert updated == 0
+    assert updated == 1
     assert updated_by_hash == 0
 
     ep1 = endpoint_service.get_by_name("test-lb-1")
@@ -142,6 +161,9 @@ def test_sync_endpoints(session):
     assert len(ep3.sni_certificates) == 2
     assert ep3.sni_certificates[0].name == crt1.name
     assert ep3.sni_certificates[1].name == crt2.name
+
+    ep4 = endpoint_service.get_by_name("test-lb-4")
+    assert ep4.primary_certificate.name == crt2.name
 
 
 @pytest.mark.parametrize(

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -53,6 +53,7 @@ def test_sync_endpoints(session):
 
     crt1 = CertificateFactory()
     crt2 = CertificateFactory()
+    crt3 = CertificateFactory()
     existing_endpoint = EndpointFactory(name="test-lb-4", dnsname="test4.example.com", port=443)
     existing_endpoint.primary_certificate = crt1
     existing_endpoint.source = source
@@ -134,7 +135,13 @@ def test_sync_endpoints(session):
                     path="/fakecrt2",
                     registry_type="iam",
                 ),
-                sni_certificates=[],
+                sni_certificates=[
+                    dict(
+                        name=crt3.name,
+                        path="/fakecrt3",
+                        registry_type="iam",
+                    )
+                ],
                 registry_type="iam",
             )
         ],
@@ -165,6 +172,8 @@ def test_sync_endpoints(session):
 
     ep4 = endpoint_service.get_by_name("test-lb-4")
     assert ep4.primary_certificate.name == crt2.name
+    assert len(ep4.sni_certificates) == 1
+    assert ep4.sni_certificates[0].name == crt3.name
 
 
 @pytest.mark.parametrize(

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -53,8 +53,9 @@ def test_sync_endpoints(session):
 
     crt1 = CertificateFactory()
     crt2 = CertificateFactory()
-    existing_endpoint = EndpointFactory(name="test-lb-4", dnsname="test4.example.com")
+    existing_endpoint = EndpointFactory(name="test-lb-4", dnsname="test4.example.com", port=443)
     existing_endpoint.primary_certificate = crt1
+    existing_endpoint.source = source
     session.commit()
 
     with mock.patch.object(


### PR DESCRIPTION
In https://github.com/DataDog/lemur/pull/9/commits/cf1d5c57cfdd40dcf85f6bb6ba54731c14a473d8 a regression was inadvertently introduced which was causing the sync source task to fail when updating an existing endpoint. It was not caught because the test cases did not exercise the update path thoroughly enough. This PR addresses both issues.

