### PR TITLE
Refactor google oauth token logic

### DIFF
--- a/lemur/plugins/lemur_gcp/plugin.py
+++ b/lemur/plugins/lemur_gcp/plugin.py
@@ -1,5 +1,6 @@
 from flask import current_app
 from google.cloud.compute_v1.services import ssl_certificates
+from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 import hvac
 import os

--- a/lemur/plugins/lemur_gcp/plugin.py
+++ b/lemur/plugins/lemur_gcp/plugin.py
@@ -1,7 +1,6 @@
 from flask import current_app
 from google.cloud.compute_v1.services import ssl_certificates
-from google.oauth2 import service_account
-import google.auth
+from google.oauth2.credentials import Credentials
 import hvac
 import os
 
@@ -94,8 +93,8 @@ class GCPDestinationPlugin(DestinationPlugin):
             roleset="",
             mount_point=f"{self.get_option('vaultMountPoint', options)}"
         )["data"]["token"].rstrip(".")
-        credentials, _ = google.auth.default()  # Fetches default GCP credentials for the current environment
-        credentials.token = service_token  # replace default credentials with oauth2 token fetched from vault
+
+        credentials = Credentials(service_token)
 
         return credentials
 


### PR DESCRIPTION
**Background**
After releasing the GCP code to production yesterday Bob noticed that cert uploads were failing for GCP with the following error.
```
Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application
```
 The call for `google.auth.default()` fails because the api cant find any default credentials for the commercial lemur environment. 
 
**Solution**
The way I was setting the token before was slightly "hacky",  because I was leaning on Googles ADC pattern to determine how to get the default credentials and then overriding that with the oauth token received from vault.  This PR refactors that logic to use the `google.oauth2.credentials` module, this is actually the method that google recommends for passing in user credentials. 
 
