### PR TITLE
[bugfix] fix certificate chain issue with GCP destination

### DIFF
--- a/lemur/plugins/lemur_gcp/plugin.py
+++ b/lemur/plugins/lemur_gcp/plugin.py
@@ -52,7 +52,7 @@ class GCPDestinationPlugin(DestinationPlugin):
         try:
             ssl_certificate_body = {
                 "name": self._certificate_name(body),
-                "certificate": body,
+                "certificate": self._full_ca(body, cert_chain),
                 "description": "",
                 "private_key": private_key,
             }
@@ -122,3 +122,7 @@ class GCPDestinationPlugin(DestinationPlugin):
         gcp_name = gcp_name.rstrip('.*-')
 
         return gcp_name
+
+    def _full_ca(self, body, cert_chain):
+        # in GCP you need to assemble the cert body and the cert chain in the same parameter
+        return f"{body}\n{cert_chain}"

--- a/lemur/plugins/lemur_gcp/tests/test_plugin.py
+++ b/lemur/plugins/lemur_gcp/tests/test_plugin.py
@@ -85,7 +85,7 @@ def test_upload(mock_ssl_certificates, mock_credentials, mock_gcp_account_id):
 
     ssl_certificate_body = {
         "name": name,
-        "certificate": body,
+        "certificate":  GCPDestinationPlugin()._full_ca(body, cert_chain),
         "description": "",
         "private_key": private_key,
     }
@@ -122,3 +122,7 @@ def test_certificate_name():
 )
 def test_modify_cert_name_for_gcp(original_cert_name, gcp_cert_name):
     assert GCPDestinationPlugin()._modify_cert_name_for_gcp(original_cert_name) == gcp_cert_name
+
+
+def test_full_ca():
+    assert GCPDestinationPlugin()._full_ca(body, cert_chain) == f"{body}\n{cert_chain}"

--- a/lemur/plugins/lemur_gcp/tests/test_plugin.py
+++ b/lemur/plugins/lemur_gcp/tests/test_plugin.py
@@ -85,7 +85,7 @@ def test_upload(mock_ssl_certificates, mock_credentials, mock_gcp_account_id):
 
     ssl_certificate_body = {
         "name": name,
-        "certificate":  GCPDestinationPlugin()._full_ca(body, cert_chain),
+        "certificate": GCPDestinationPlugin()._full_ca(body, cert_chain),
         "description": "",
         "private_key": private_key,
     }


### PR DESCRIPTION
For the GCP API you need to have the certificate chain included with the certificate body, as per the [documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates/self-managed-certs#createresource).
> You can choose to include the CA certificate chain in the same file as the certificate. Google Cloud does not validate the certificate chain for you — validation is your responsibility.

This PR fixes the bug of certificates that are uploaded with the GCP Destination having a broken certificate chain. 