### PR TITLE
Add SNI support to the GCP source plugin

### DIFF
--- a/lemur/plugins/lemur_gcp/certificates.py
+++ b/lemur/plugins/lemur_gcp/certificates.py
@@ -113,6 +113,9 @@ def get_self_link(project, name):
 def calc_diff(certs, new_cert, old_cert):
     """
     Produces a list of certificate self-links where new_cert is added and old_cert is removed, if it exists.
+    The given certs are assumed to be unique and this is a no-op if new_cert and old_cert are the same.
+    If new_cert already exists in certs, it will not be added.
+    If old_cert already does not exist in certs, this is a no-op.
     :param certs:
     :param new_cert:
     :param old_cert:
@@ -120,13 +123,20 @@ def calc_diff(certs, new_cert, old_cert):
     """
     # Shallow copy the list of self-links (strings)
     result = list(certs)
-    new_cert_idx = -1
-    for idx, self_link in enumerate(certs):
+    if len(result) != len(set(result)):
+        raise Exception("expected given certs to be unique")
+    if new_cert == old_cert:
+        return result
+    old_cert_idx = -1
+    for idx, self_link in enumerate(result):
         if self_link == old_cert:
-            new_cert_idx = idx
+            old_cert_idx = idx
             break
-    if new_cert_idx != -1:
-        result[new_cert_idx] = new_cert
-    else:
-        result.append(new_cert)
+    if new_cert not in result:
+        if old_cert_idx != -1:
+            result[old_cert_idx] = new_cert
+        else:
+            result.append(new_cert)
+    if old_cert in result:
+        result.remove(old_cert)
     return result

--- a/lemur/plugins/lemur_gcp/certificates.py
+++ b/lemur/plugins/lemur_gcp/certificates.py
@@ -118,12 +118,15 @@ def calc_diff(certs, new_cert, old_cert):
     :param old_cert:
     :return:
     """
-    result = []
-    for self_link in certs:
-        if self_link != old_cert:
-            result.append(self_link)
-        if self_link == new_cert:
-            continue
-    if new_cert not in result:
+    # Shallow copy the list of self-links (strings)
+    result = list(certs)
+    new_cert_idx = -1
+    for idx, self_link in enumerate(certs):
+        if self_link == old_cert:
+            new_cert_idx = idx
+            break
+    if new_cert_idx != -1:
+        result[new_cert_idx] = new_cert
+    else:
         result.append(new_cert)
     return result

--- a/lemur/plugins/lemur_gcp/certificates.py
+++ b/lemur/plugins/lemur_gcp/certificates.py
@@ -104,3 +104,26 @@ def parse_certificate_meta(certificate_meta):
         chain="\n".join(chain[1:]),
         name=certificate_meta.name,
     )
+
+
+def get_self_link(project, name):
+    return f"https://www.googleapis.com/compute/v1/projects/{project}/global/sslCertificates/{name}"
+
+
+def calc_diff(certs, new_cert, old_cert):
+    """
+    Produces a list of certificate self-links where new_cert is added and old_cert is removed, if it exists.
+    :param certs:
+    :param new_cert:
+    :param old_cert:
+    :return:
+    """
+    result = []
+    for self_link in certs:
+        if self_link != old_cert:
+            result.append(self_link)
+        if self_link == new_cert:
+            continue
+    if new_cert not in result:
+        result.append(new_cert)
+    return result

--- a/lemur/plugins/lemur_gcp/endpoints.py
+++ b/lemur/plugins/lemur_gcp/endpoints.py
@@ -109,13 +109,11 @@ def update_target_proxy_default_cert(project_id, credentials, endpoint, certific
     if kind == "targethttpsproxy":
         client = target_https_proxies.TargetHttpsProxiesClient(credentials=credentials)
         proxy = client.get(project=project_id, target_https_proxy=endpoint.name)
-        existing_certs = proxy.ssl_certificates if len(proxy.ssl_certificates) > 0 else []
-        set_target_ssl_proxy_certs(project_id, client, endpoint, [cert_self_link] + existing_certs)
+        set_target_https_proxy_certs(project_id, client, endpoint, [cert_self_link] + proxy.ssl_certificates)
     elif kind == "targetsslproxy":
         client = target_ssl_proxies.TargetSslProxiesClient(credentials=credentials)
         proxy = client.get(project=project_id, target_ssl_proxy=endpoint.name)
-        existing_certs = proxy.ssl_certificates if len(proxy.ssl_certificates) > 0 else []
-        set_target_ssl_proxy_certs(project_id, client, endpoint, [cert_self_link] + existing_certs)
+        set_target_ssl_proxy_certs(project_id, client, endpoint, [cert_self_link] + proxy.ssl_certificates)
 
 
 def set_target_https_proxy_certs(project_id, client, endpoint, certificate_self_links):

--- a/lemur/plugins/lemur_gcp/endpoints.py
+++ b/lemur/plugins/lemur_gcp/endpoints.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
-from google.cloud.compute_v1.services import ssl_certificates, ssl_policies, \
-    global_forwarding_rules, target_https_proxies, target_ssl_proxies
+from flask import current_app
+
+from google.cloud.compute_v1.services import ssl_policies, global_forwarding_rules, \
+    target_https_proxies, target_ssl_proxies
 from google.cloud.compute_v1 import TargetHttpsProxiesSetSslCertificatesRequest, \
     TargetSslProxiesSetSslCertificatesRequest
 
@@ -20,22 +22,21 @@ def fetch_target_proxies(project_id, credentials):
     http_proxies_client = target_https_proxies.TargetHttpsProxiesClient(credentials=credentials)
     ssl_policies_client = ssl_policies.SslPoliciesClient(credentials=credentials)
     for proxy in http_proxies_client.list(project=project_id):
-        endpoint = get_endpoint_from_proxy(project_id, credentials, proxy, ssl_policies_client, forwarding_rules_map)
+        endpoint = get_endpoint_from_proxy(project_id, proxy, ssl_policies_client, forwarding_rules_map)
         if endpoint:
             endpoints.append(endpoint)
     ssl_proxies_client = target_ssl_proxies.TargetSslProxiesClient(credentials=credentials)
     for proxy in ssl_proxies_client.list(project=project_id):
-        endpoint = get_endpoint_from_proxy(project_id, credentials, proxy, ssl_policies_client, forwarding_rules_map)
+        endpoint = get_endpoint_from_proxy(project_id, proxy, ssl_policies_client, forwarding_rules_map)
         if endpoint:
             endpoints.append(endpoint)
     return endpoints
 
 
-def get_endpoint_from_proxy(project_id, credentials, proxy, ssl_policies_client, forwarding_rules_map):
+def get_endpoint_from_proxy(project_id, proxy, ssl_policies_client, forwarding_rules_map):
     """
     Converts a proxy (either HTTPs or SSL) into a Lemur endpoint.
     :param project_id:
-    :param credentials:
     :param proxy:
     :param ssl_policies_client:
     :param forwarding_rules_map:
@@ -49,17 +50,6 @@ def get_endpoint_from_proxy(project_id, credentials, proxy, ssl_policies_client,
     fw_rules = forwarding_rules_map.get(proxy.self_link, None)
     if not fw_rules:
         return None
-    # The first certificate is the primary.
-    # See https://cloud.google.com/sdk/gcloud/reference/compute/target-https-proxies/update
-    ssl_cert_name = get_name_from_self_link(proxy.ssl_certificates[0])
-    cert = certificates.fetch_by_name(project_id, credentials, ssl_cert_name)
-    if not cert:
-        return None
-    primary_certificate = dict(
-        name=cert["name"],
-        registry_type="gcp",
-        path="",
-    )
     fw_rule_ingresses = []
     for rule in fw_rules:
         ip = rule.I_p_address
@@ -70,14 +60,26 @@ def get_endpoint_from_proxy(project_id, credentials, proxy, ssl_policies_client,
     endpoint = dict(
         name=proxy.name,
         type=kind,
-        primary_certificate=primary_certificate,
         dnsname=primary_ip,
         port=primary_port,
         policy=dict(
             name="",
             ciphers=[],
         ),
+        sni_certificates=[],
     )
+    for idx, self_link in enumerate(proxy.ssl_certificates):
+        crt = dict(
+            name=get_name_from_self_link(self_link),
+            path="",
+            registry_type="gcp",
+        )
+        # The first certificate is the primary.
+        # See https://cloud.google.com/sdk/gcloud/reference/compute/target-https-proxies/update
+        if idx == 0:
+            endpoint["primary_certificate"] = crt
+        else:
+            endpoint["sni_certificates"].append(crt)
     if len(fw_rule_ingresses) > 1:
         endpoint["aliases"] = [info[0] for info in fw_rule_ingresses[1:]]
     if proxy.ssl_policy:
@@ -88,9 +90,9 @@ def get_endpoint_from_proxy(project_id, credentials, proxy, ssl_policies_client,
     return endpoint
 
 
-def update_target_proxy_cert(project_id, credentials, endpoint, certificate):
+def update_target_proxy_default_cert(project_id, credentials, endpoint, certificate):
     """
-    Sets the certificate for targethttpsproxy or targetsslproxy
+    Sets the default certificate for targethttpsproxy or targetsslproxy
     :param project_id:
     :param credentials:
     :param endpoint:
@@ -100,37 +102,64 @@ def update_target_proxy_cert(project_id, credentials, endpoint, certificate):
     kind = endpoint.type
     if kind not in ("targethttpsproxy", "targetsslproxy") or endpoint.registry_type != "gcp":
         raise NotImplementedError()
-    ssl_client = ssl_certificates.SslCertificatesClient(credentials=credentials)
     # Parses the API name from the certificate body. This is because the certificate's name
     # is different from the name of the certificate that finally gets uploaded to GCP.
     cert_name = certificates.get_name(certificate.body)
-    cert_meta = ssl_client.get(project=project_id, ssl_certificate=cert_name)
+    cert_self_link = certificates.get_self_link(project_id, cert_name)
     if kind == "targethttpsproxy":
         client = target_https_proxies.TargetHttpsProxiesClient(credentials=credentials)
         proxy = client.get(project=project_id, target_https_proxy=endpoint.name)
-        if len(proxy.ssl_certificates) > 1:
-            raise NotImplementedError("GCP endpoints with multiple certificates for SNI are not supported currently.")
-        req = TargetHttpsProxiesSetSslCertificatesRequest()
-        req.ssl_certificates = [cert_meta.self_link]
-        operation = client.set_ssl_certificates(
-            project=project_id,
-            target_https_proxy=endpoint.name,
-            target_https_proxies_set_ssl_certificates_request_resource=req,
-        )
-        operation.result()
+        existing_certs = proxy.ssl_certificates if len(proxy.ssl_certificates) > 0 else []
+        set_target_ssl_proxy_certs(project_id, client, endpoint, [cert_self_link] + existing_certs)
     elif kind == "targetsslproxy":
         client = target_ssl_proxies.TargetSslProxiesClient(credentials=credentials)
         proxy = client.get(project=project_id, target_ssl_proxy=endpoint.name)
-        if len(proxy.ssl_certificates) > 1:
-            raise NotImplementedError("GCP endpoints with multiple certificates for SNI are not supported currently.")
-        req = TargetSslProxiesSetSslCertificatesRequest()
-        req.ssl_certificates = [cert_meta.self_link]
-        operation = client.set_ssl_certificates(
-            project=project_id,
-            target_ssl_proxy=endpoint.name,
-            target_ssl_proxies_set_ssl_certificates_request_resource=req,
-        )
-        operation.result()
+        existing_certs = proxy.ssl_certificates if len(proxy.ssl_certificates) > 0 else []
+        set_target_ssl_proxy_certs(project_id, client, endpoint, [cert_self_link] + existing_certs)
+
+
+def set_target_https_proxy_certs(project_id, client, endpoint, certificate_self_links):
+    current_app.logger.debug(f"Setting certificates to {certificate_self_links} for endpoint {endpoint.name}")
+    req = TargetHttpsProxiesSetSslCertificatesRequest()
+    req.ssl_certificates = certificate_self_links
+    operation = client.set_ssl_certificates(
+        project=project_id,
+        target_https_proxy=endpoint.name,
+        target_https_proxies_set_ssl_certificates_request_resource=req,
+    )
+    operation.result()
+
+
+def set_target_ssl_proxy_certs(project_id, client, endpoint, certificate_self_links):
+    current_app.logger.debug(f"Setting certificates to {certificate_self_links} for endpoint {endpoint.name}")
+    req = TargetSslProxiesSetSslCertificatesRequest()
+    req.ssl_certificates = certificate_self_links
+    operation = client.set_ssl_certificates(
+        project=project_id,
+        target_ssl_proxy=endpoint.name,
+        target_ssl_proxies_set_ssl_certificates_request_resource=req,
+    )
+    operation.result()
+
+
+def update_target_proxy_sni_certs(project_id, credentials, endpoint, old_cert, new_cert):
+    kind = endpoint.type
+    if kind not in ("targethttpsproxy", "targetsslproxy") or endpoint.registry_type != "gcp":
+        raise NotImplementedError()
+    old_cert_name = certificates.get_name(old_cert.body)
+    old_cert_self_link = certificates.get_self_link(project_id, old_cert_name)
+    new_cert_name = certificates.get_name(new_cert.body)
+    new_cert_self_link = certificates.get_self_link(project_id, new_cert_name)
+    if kind == "targethttpsproxy":
+        client = target_https_proxies.TargetHttpsProxiesClient(credentials=credentials)
+        proxy = client.get(project=project_id, target_https_proxy=endpoint.name)
+        certs = certificates.calc_diff(proxy.ssl_certificates, new_cert_self_link, old_cert_self_link)
+        set_target_https_proxy_certs(project_id, client, endpoint, certs)
+    elif kind == "targetsslproxy":
+        client = target_ssl_proxies.TargetSslProxiesClient(credentials=credentials)
+        proxy = client.get(project=project_id, target_ssl_proxy=endpoint.name)
+        certs = certificates.calc_diff(proxy.ssl_certificates, new_cert_self_link, old_cert_self_link)
+        set_target_ssl_proxy_certs(project_id, client, endpoint, certs)
 
 
 def fetch_global_forwarding_rules_map(project_id, credentials):

--- a/lemur/plugins/lemur_gcp/plugin.py
+++ b/lemur/plugins/lemur_gcp/plugin.py
@@ -152,24 +152,10 @@ class GCPSourcePlugin(SourcePlugin):
         options = endpoint.source.options
         credentials = auth.get_gcp_credentials(self, options)
         project_id = self.get_option("projectID", options)
-        try:
-            update_target_proxy_default_cert(project_id, credentials, endpoint, certificate)
-        except Exception as e:
-            current_app.logger.error(
-                f"Issue with updating endpoint in GCP. Action failed with the following log: {e}",
-                exc_info=True,
-            )
-            raise Exception(f"Issue updating endpoint in GCP: {e}")
+        update_target_proxy_default_cert(project_id, credentials, endpoint, certificate)
 
     def replace_sni_certificate(self, endpoint, old_cert, new_cert):
         options = endpoint.source.options
         credentials = auth.get_gcp_credentials(self, options)
         project_id = self.get_option("projectID", options)
-        try:
-            update_target_proxy_sni_certs(project_id, credentials, endpoint, old_cert, new_cert)
-        except Exception as e:
-            current_app.logger.error(
-                f"Issue with updating endpoint in GCP. Action failed with the following log: {e}",
-                exc_info=True,
-            )
-            raise Exception(f"Issue updating endpoint in GCP: {e}")
+        update_target_proxy_sni_certs(project_id, credentials, endpoint, old_cert, new_cert)

--- a/lemur/plugins/lemur_gcp/readme.md
+++ b/lemur/plugins/lemur_gcp/readme.md
@@ -24,7 +24,8 @@ In the field labeled "Service Account Token Path" enter in the path to where you
 ## Source
 The source plugin allows Lemur to discover certificates and endpoints in a given GCP account.
 Authentication is handled the same way as the destination plugin. The plugin currently supports
-fetching global endpoints (i.e. global HTTPS proxies and global SSL proxies).
+fetching global endpoints (i.e. global HTTPS proxies and global SSL proxies), fetching self-managed
+certificates and rotating the primary certificate and SNI certificates for global endpoints.
 
 #### Testing Source plugin locally
 See `Testing Destination plugin locally`. By default, the source sync is done every 15 minutes.

--- a/lemur/plugins/lemur_gcp/tests/test_certificates.py
+++ b/lemur/plugins/lemur_gcp/tests/test_certificates.py
@@ -67,7 +67,10 @@ def test_get_self_link():
         (["a", "b"], "c", "b", ["a", "c"]),
         (["a"], "c", "b", ["a", "c"]),
         (["a", "b"], "b", "b", ["a", "b"]),
-        (["a", "b"], "c", "a", ["c", "b"])
+        (["a", "b"], "c", "a", ["c", "b"]),
+        (["a", "b", "c"], "d", "e", ["a", "b", "c", "d"]),
+        (["a", "b", "c"], "c", "d", ["a", "b", "c"]),
+        (["a", "b"], "a", "b", ["a"])
     ]
 )
 def test_calc_certs(certs, new_cert, old_cert, expected):

--- a/lemur/plugins/lemur_gcp/tests/test_certificates.py
+++ b/lemur/plugins/lemur_gcp/tests/test_certificates.py
@@ -54,3 +54,20 @@ def test_modify_for_gcp(original_cert_name, gcp_cert_name):
 
 def test_full_ca():
     assert certificates.full_ca(body, cert_chain) == f"{body}\n{cert_chain}"
+
+
+def test_get_self_link():
+    assert certificates.get_self_link("sandbox", "cert1") == \
+           "https://www.googleapis.com/compute/v1/projects/sandbox/global/sslCertificates/cert1"
+
+
+@pytest.mark.parametrize(
+    ("certs", "new_cert", "old_cert", "expected"),
+    [
+        (["a", "b"], "c", "b", ["a", "c"]),
+        (["a"], "c", "b", ["a", "c"]),
+        (["a", "b"], "b", "b", ["a", "b"])
+    ]
+)
+def test_calc_certs(certs, new_cert, old_cert, expected):
+    assert certificates.calc_diff(certs, new_cert, old_cert) == expected

--- a/lemur/plugins/lemur_gcp/tests/test_certificates.py
+++ b/lemur/plugins/lemur_gcp/tests/test_certificates.py
@@ -66,7 +66,8 @@ def test_get_self_link():
     [
         (["a", "b"], "c", "b", ["a", "c"]),
         (["a"], "c", "b", ["a", "c"]),
-        (["a", "b"], "b", "b", ["a", "b"])
+        (["a", "b"], "b", "b", ["a", "b"]),
+        (["a", "b"], "c", "a", ["c", "b"])
     ]
 )
 def test_calc_certs(certs, new_cert, old_cert, expected):

--- a/lemur/plugins/lemur_gcp/tests/test_certificates.py
+++ b/lemur/plugins/lemur_gcp/tests/test_certificates.py
@@ -64,13 +64,16 @@ def test_get_self_link():
 @pytest.mark.parametrize(
     ("certs", "new_cert", "old_cert", "expected"),
     [
+        # new cert does not exist, old cert exists at end
         (["a", "b"], "c", "b", ["a", "c"]),
+        # new cert does not exist, old cert does not exist
         (["a"], "c", "b", ["a", "c"]),
+        # new cert matches old cert
         (["a", "b"], "b", "b", ["a", "b"]),
-        (["a", "b"], "c", "a", ["c", "b"]),
-        (["a", "b", "c"], "d", "e", ["a", "b", "c", "d"]),
+        # new cert does exist, old cert does not exist
         (["a", "b", "c"], "c", "d", ["a", "b", "c"]),
-        (["a", "b"], "a", "b", ["a"])
+        # new cert exists, old cert exists
+        (["a", "b"], "a", "b", ["a"]),
     ]
 )
 def test_calc_certs(certs, new_cert, old_cert, expected):

--- a/lemur/plugins/lemur_gcp/tests/test_endpoints.py
+++ b/lemur/plugins/lemur_gcp/tests/test_endpoints.py
@@ -23,7 +23,7 @@ def test_get_endpoint_from_proxy():
     proxy = types.TargetHttpsProxy()
     proxy.name = "test-https-proxy"
     proxy.kind = "compute#targetHttpsProxy"
-    proxy.ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/staging/global/sslCertificates/auth"]
+    proxy.ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/staging/global/sslCertificates/cert1"]
     proxy.self_link = target1_self_link
     proxy.ssl_policy = "https://www.googleapis.com/compute/v1/projects/staging/global/sslPolicies/policy1"
 
@@ -42,4 +42,4 @@ def test_get_endpoint_from_proxy():
     assert endpoint["port"] == "443"
     assert endpoint["aliases"] == ["1.2.3.5"]
     assert endpoint["policy"] == {"name": "policy1", "ciphers": ["TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"]}
-    assert endpoint["primary_certificate"] == {"name": "auth", "registry_type": "gcp", "path": ""}
+    assert endpoint["primary_certificate"] == {"name": "cert1", "registry_type": "gcp", "path": ""}

--- a/lemur/plugins/lemur_gcp/tests/test_endpoints.py
+++ b/lemur/plugins/lemur_gcp/tests/test_endpoints.py
@@ -1,7 +1,5 @@
-import unittest.mock
 from unittest import mock
 from collections import defaultdict
-from unittest.mock import MagicMock
 from google.cloud.compute_v1 import types
 
 target1_self_link = "https://www.googleapis.com/compute/v1/projects/staging/global/targetHttpsProxies/target1"
@@ -20,10 +18,7 @@ forwarding_rules = defaultdict(list)
 forwarding_rules[target1_self_link] = [fw_rule_1, fw_rule_2]
 
 
-@unittest.mock.patch("lemur.plugins.lemur_gcp.certificates.fetch_by_name", return_value=dict(
-    body="", chain="", name="cert1"
-))
-def test_get_endpoint_from_proxy(mock_cert):
+def test_get_endpoint_from_proxy():
     from lemur.plugins.lemur_gcp.endpoints import get_endpoint_from_proxy
     proxy = types.TargetHttpsProxy()
     proxy.name = "test-https-proxy"
@@ -38,8 +33,7 @@ def test_get_endpoint_from_proxy(mock_cert):
     ssl_policies_client = mock.Mock()
     ssl_policies_client.get.return_value = policy
 
-    credentials = MagicMock()
-    endpoint = get_endpoint_from_proxy("123", credentials, proxy, ssl_policies_client, forwarding_rules)
+    endpoint = get_endpoint_from_proxy("123", proxy, ssl_policies_client, forwarding_rules)
     assert endpoint is not None
     ssl_policies_client.get.assert_called_once_with(project="123", ssl_policy="policy1")
     assert endpoint["name"] == "test-https-proxy"
@@ -48,4 +42,4 @@ def test_get_endpoint_from_proxy(mock_cert):
     assert endpoint["port"] == "443"
     assert endpoint["aliases"] == ["1.2.3.5"]
     assert endpoint["policy"] == {"name": "policy1", "ciphers": ["TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"]}
-    assert endpoint["primary_certificate"] == {"name": "cert1", "registry_type": "gcp", "path": ""}
+    assert endpoint["primary_certificate"] == {"name": "auth", "registry_type": "gcp", "path": ""}


### PR DESCRIPTION
This adds support for SNI certificates when listing certificates attached to an endpoint/LB and rotating a cert on an endpoint with multiple certificates. Note, GCP treats the first certificate in its list as the primary and `update_endpoint` is called by Lemur specifically when updating the primary - `replace_sni_certificate` is called by Lemur when replacing the non-primary. The order for `certificates[1:]` attached to a target proxy does not matter.

Changes:
* Fetch metadata for non-primary certificates attached to a target proxy
* Implement `replace_sni_certificate` so Lemur can rotate non-primary certs in addition to just the primary cert
* Remove some unnecessary API calls when setting the certs on a target proxy 