### PR TITLE
Support syncing certificates and ssl policies in Azure source plugin

### DIFF
--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -32,6 +32,7 @@ def certificate_from_id(appgw, certificate_id):
         if cert.id == certificate_id:
             return dict(
                 name=cert.name,
+                path="",
                 registry_type="keyvault",
             )
     raise Exception(f"No certificate with ID {certificate_id} associated with {appgw.id}")

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -182,7 +182,7 @@ class AzureDestinationPlugin(DestinationPlugin):
         # Azure does not allow "." in the certificate name we replace them with "-"
         cert = parse_certificate(body)
         ca_certs = parse_certificate(cert_chain)
-        certificate_name = f"{common_name(cert).replace('.', '-')}-{issuer(cert)}"
+        certificate_name = f"{common_name(cert).replace('.', '-').replace('*', 'star')}-{issuer(cert)}"
 
         certificate_client = CertificateClient(
             credential=get_azure_credential(self, options),

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -178,8 +178,8 @@ class AzureDestinationPlugin(DestinationPlugin):
         :return:
         """
 
-        # we use the common name to identify the certificate
-        # Azure does not allow "." in the certificate name we replace them with "-"
+        # The certificate name must be a 1-127 character string, starting with a letter
+        # and containing only 0-9, a-z, A-Z, and -.
         cert = parse_certificate(body)
         ca_certs = parse_certificate(cert_chain)
         certificate_name = f"{common_name(cert).replace('.', '-').replace('*', 'star')}-{issuer(cert)}"

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -15,7 +15,7 @@ from azure.keyvault.certificates import CertificateClient, CertificatePolicy
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.subscription import SubscriptionClient
-from azure.mgmt.network.models import ApplicationGatewaySslCipherSuite
+from azure.mgmt.network.models import ApplicationGatewaySslPolicyName, ApplicationGatewaySslCipherSuite
 
 from lemur.common.defaults import common_name, issuer, bitstrength
 from lemur.common.utils import parse_certificate, parse_private_key, check_validation
@@ -35,9 +35,13 @@ def policy_from_appgw(appgw):
             ciphers=[],
         )
     policy = dict(
-        name=appgw.ssl_policy.policy_name,
+        name="",
         ciphers=[],
     )
+    if isinstance(appgw.ssl_policy.policy_name, ApplicationGatewaySslPolicyName):
+        policy["name"] = appgw.ssl_policy.policy_name.value
+    else:
+        policy["name"] = appgw.ssl_policy.policy_name
     if appgw.ssl_policy.cipher_suites:
         for c in appgw.ssl_policy.cipher_suites:
             if isinstance(c, ApplicationGatewaySslCipherSuite):

--- a/lemur/plugins/lemur_azure/tests/test_azure_source.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_source.py
@@ -37,6 +37,14 @@ class TestAzureSource(unittest.TestCase):
         self.azure_source = plugin.AzureSourcePlugin()
 
     @patch.dict(os.environ, {"VAULT_ADDR": "https://fakevaultinstance:8200"})
+    def test_get_certificate_by_name(self):
+        pass
+
+    @patch.dict(os.environ, {"VAULT_ADDR": "https://fakevaultinstance:8200"})
+    def test_get_certificates(self):
+        pass
+
+    @patch.dict(os.environ, {"VAULT_ADDR": "https://fakevaultinstance:8200"})
     @patch("azure.mgmt.network.v2022_05_01.operations.PublicIPAddressesOperations.get")
     @patch("azure.mgmt.network.v2022_05_01.operations.ApplicationGatewaysOperations.list_all")
     @patch("azure.mgmt.subscription.operations.SubscriptionsOperations.list")

--- a/lemur/plugins/lemur_azure/tests/test_azure_source.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_source.py
@@ -14,6 +14,7 @@ from azure.mgmt.network.models import (
     ApplicationGatewayHttpListener,
     ApplicationGatewaySslCertificate,
     ApplicationGatewaySslPolicy,
+    ApplicationGatewaySslPolicyName,
     ApplicationGatewaySslCipherSuite,
     PublicIPAddress,
     SubResource
@@ -42,6 +43,33 @@ oSd+GXhOxThRj9euiyP/NA0JbCdrv4z5UEWZ2+U+lsLALoXBZqQAgDpZNggsujqn
 o0BydDBcgoQtQ3w5e9k5Upah6f+X0ZryXQemC/BnjKSdXipkcg295WyV780jTQV1
 9+NK9wF8ED74VGLaqAHjTT2UmVfiyPs7kxU+KqYzLfl2GL49RDcf4V06q5pr/JmR
 tXwUxRyH8L1hRMfyCE/35EhVTmPdc3lRaPXROD1gtuRDEQIb
+-----END CERTIFICATE-----
+"""
+
+test_server_cert_2 = """-----BEGIN CERTIFICATE-----
+MIIEJDCCAwygAwIBAgIPK/QvcZhAY7VPU7Ek/nCDMA0GCSqGSIb3DQEBCwUAMIGn
+MS0wKwYDVQQDDCRMZW11clRydXN0IFVuaXR0ZXN0cyBDbGFzcyAxIENBIDIwMTgx
+IzAhBgNVBAoMGkxlbXVyVHJ1c3QgRW50ZXJwcmlzZXMgTHRkMSYwJAYDVQQLDB1V
+bml0dGVzdGluZyBPcGVyYXRpb25zIENlbnRlcjELMAkGA1UEBhMCRUUxDDAKBgNV
+BAgMA04vQTEOMAwGA1UEBwwFRWFydGgwHhcNMTcxMjMxMjIwMDAwWhcNNDcxMjMx
+MjIwMDAwWjB9MRswGQYDVQQDDBIqLndpbGQuZXhhbXBsZS5vcmcxETAPBgNVBAoM
+CFBsYXl0ZWNoMRkwFwYDVQQLDBBJbmZyYSBPcGVyYXRpb25zMQswCQYDVQQGEwJF
+RTERMA8GA1UECAwISGFyanVtYWExEDAOBgNVBAcMB1RhbGxpbm4wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCoT8Ak5kynUzosBvP8hCnP4hGMAtgHLcHG
+UBWug4BofAhxxBrZW3UteoQzNznK5jz0hy2azqnz3/9q5N/FKwHxfMY/VEHPXyYK
+QsZuSdVceJ/EHL+MLx+uisIRJstV8fC5oYRfg74m07ZED7NM4EerJTxKZAy7UuSM
+L65i/LEChPzjLN46GcUEuC2O03nZtFTPvN9j7vzen9/qIzs1TGQukOn4z5l2GuAx
+RCEfBl3IrnvSY+npGARPJsXSymXCCP3ntzq6I6iRHuZf+QETZtiMR1TCNZRTqcc2
+LxWn+W5N18yyXvUcVMfrg4jzEWKHuhwInoiH1pu/myyKrnoIi4nTAgMBAAGjdjB0
+MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA4GA1UdDwEB/wQEAwIFoDAMBgNVHRMBAf8E
+AjAAMB0GA1UdDgQWBBRR9Q9DHJRPt69Qm8lir4iJfOmJ4TAgBgNVHREBAf8EFjAU
+ghIqLndpbGQuZXhhbXBsZS5vcmcwDQYJKoZIhvcNAQELBQADggEBAMm2DiYfGLve
+r/gCtYgXKkRmbuv57PmAUm52w5l4hjxssdUwq4Wn4T+K0+Sqp3IzcNhEaIqPB+bG
+8rIbJLBiiDPbSUZC0DbvlXihk7FHjqmrbVFwNmkWNywLhB1qOlp0kQH+w9lDWA1p
+y99P0Bxcot66scbiaag0i0AUpkRKbUG+v+VGXdPrJrWE+63ROhWQMmQNiUlZ6QGO
+45tUSn//MuUpJiJVkUVR1fSbCpHQj2mHiuhShOmatmh5e1ISwVP19cX64Gr6djlY
+wKJqcmw7WDjl+T+y7luJWw4UqI7s7hY6Y9RQVh61L4eV8CIma3NmTaQCSgR3tCxh
+d4FCKAE8+Lw=
 -----END CERTIFICATE-----
 """
 
@@ -144,7 +172,7 @@ class TestAzureSource(unittest.TestCase):
             ssl_policy=ApplicationGatewaySslPolicy(
                 policy_name="AppGwSslPolicy20170401S",
                 cipher_suites=[
-                    ApplicationGatewaySslCipherSuite("TLS_RSA_WITH_AES_256_CBC_SHA"),
+                    "TLS_RSA_WITH_AES_256_CBC_SHA",
                 ]
             ),
         )
@@ -262,7 +290,7 @@ class TestAzureSource(unittest.TestCase):
                 )
             ],
             ssl_policy=ApplicationGatewaySslPolicy(
-                policy_name="AppGwSslPolicy20170401S",
+                policy_name=ApplicationGatewaySslPolicyName("AppGwSslPolicy20170401S"),
                 cipher_suites=[
                     ApplicationGatewaySslCipherSuite("TLS_RSA_WITH_AES_256_CBC_SHA"),
                 ]

--- a/lemur/plugins/lemur_azure/tests/test_azure_source.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_source.py
@@ -240,6 +240,7 @@ class TestAzureSource(unittest.TestCase):
                 type="applicationgateway",
                 primary_certificate=dict(
                     name="fake-ssl-certificate-foo",
+                    path="",
                     registry_type="keyvault",
                 ),
                 sni_certificates=[],
@@ -251,6 +252,7 @@ class TestAzureSource(unittest.TestCase):
                 type="applicationgateway",
                 primary_certificate=dict(
                     name="fake-ssl-certificate-baz-1",
+                    path="",
                     registry_type="keyvault",
                 ),
                 sni_certificates=[],
@@ -262,6 +264,7 @@ class TestAzureSource(unittest.TestCase):
                 type="applicationgateway",
                 primary_certificate=dict(
                     name="fake-ssl-certificate-baz-2",
+                    path="",
                     registry_type="keyvault",
                 ),
                 sni_certificates=[],

--- a/lemur/plugins/lemur_azure/tests/test_azure_source.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_source.py
@@ -11,6 +11,8 @@ from azure.mgmt.network.models import (
     ApplicationGatewayFrontendPort,
     ApplicationGatewayHttpListener,
     ApplicationGatewaySslCertificate,
+    ApplicationGatewaySslPolicy,
+    ApplicationGatewaySslCipherSuite,
     PublicIPAddress,
     SubResource
 )
@@ -97,6 +99,12 @@ class TestAzureSource(unittest.TestCase):
                     name="fake-ssl-certificate-foo",
                 )
             ],
+            ssl_policy=ApplicationGatewaySslPolicy(
+                policy_name="AppGwSslPolicy20170401S",
+                cipher_suites=[
+                    ApplicationGatewaySslCipherSuite("TLS_RSA_WITH_AES_256_CBC_SHA"),
+                ]
+            ),
         )
         foo_public_ip = PublicIPAddress(
             id=_public_ip_resource_id(subscription_id="fake-subscription-1", resource_name="fake-public-ipv4-foo-1"),
@@ -133,15 +141,8 @@ class TestAzureSource(unittest.TestCase):
                 ApplicationGatewayFrontendPort(
                     id=_frontend_port_id(subscription_id="fake-subscription-1", appgw_name="fake-appgw-bar",
                                          resource_name="fake-frontend-port-bar"),
-                    port=443,
+                    port=80,
                 ),
-            ],
-            ssl_certificates=[
-                ApplicationGatewaySslCertificate(
-                    id=_ssl_certificate_id(subscription_id="fake-subscription-1", appgw_name="fake-appgw-bar",
-                                           resource_name="fake-ssl-certificate-bar"),
-                    name="fake-ssl-certificate-bar",
-                )
             ],
         )
         bar_appgw.name = "fake-appgw-bar-plaintext-only"
@@ -218,6 +219,12 @@ class TestAzureSource(unittest.TestCase):
                     name="fake-ssl-certificate-baz-2",
                 )
             ],
+            ssl_policy=ApplicationGatewaySslPolicy(
+                policy_name="AppGwSslPolicy20170401S",
+                cipher_suites=[
+                    ApplicationGatewaySslCipherSuite("TLS_RSA_WITH_AES_256_CBC_SHA"),
+                ]
+            ),
         )
         baz_appgw.name = "fake-appgw-baz"
         baz_public_ip = PublicIPAddress(
@@ -252,6 +259,10 @@ class TestAzureSource(unittest.TestCase):
                     registry_type="keyvault",
                 ),
                 sni_certificates=[],
+                policy=dict(
+                    name="AppGwSslPolicy20170401S",
+                    ciphers=["TLS_RSA_WITH_AES_256_CBC_SHA"],
+                )
             ),
             dict(
                 name="fake-appgw-baz-public-443",
@@ -264,6 +275,10 @@ class TestAzureSource(unittest.TestCase):
                     registry_type="keyvault",
                 ),
                 sni_certificates=[],
+                policy=dict(
+                    name="AppGwSslPolicy20170401S",
+                    ciphers=["TLS_RSA_WITH_AES_256_CBC_SHA"],
+                )
             ),
             dict(
                 name="fake-appgw-baz-internal-443",
@@ -276,5 +291,9 @@ class TestAzureSource(unittest.TestCase):
                     registry_type="keyvault",
                 ),
                 sni_certificates=[],
+                policy=dict(
+                    name="AppGwSslPolicy20170401S",
+                    ciphers=["TLS_RSA_WITH_AES_256_CBC_SHA"],
+                )
             ),
         ]

--- a/lemur/plugins/lemur_azure/tests/test_azure_source.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_source.py
@@ -36,6 +36,24 @@ class TestAzureSource(unittest.TestCase):
     def setUp(self):
         self.azure_source = plugin.AzureSourcePlugin()
 
+    def test_pem_encode_key_vault_certificate_contents(self):
+        input = "MIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDASBgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1OVowFzEVMBMGA1UEAxMMS2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzMBMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+OXHSNbsLdmMhni0jYX09h3XlC2VJw2sGKeYF+xEaavXm337aZZaZyjrFBrrUl51UePaN+kVFXNlBb3N3TYpqa7KokXenJQuR+i9Gv9a77c0UsSsDSryxppYhKK7HvTZCpKrhVtulF5iPMswWe9np3uggfMamyIsK/0L7X9w9B2qN7993RR0A00nOk4H6CnkuwO77dSsD0KJsk6FyAoZBzRXDZh9+d9R76zCL506NcQy/jl0lCiQYwsUX73PG5pxOh02OwKwIDAQABo0swSTBHBgNVHQEEQDA+gBAS5AktBh0dTwCNYSHcFmRjoRgwFjEUMBIGA1UEAxMLUm9vdCBBZ2VuY3mCEAY3bACqAGSKEc+41KpcNfQwCQYFKw4DAh0FAANBAGqIjo2geVagzuzaZOe1ClGKhZeiCKfWAxklaGN+qlGUbVS4IN4V1lot3VKnzabasmkEHeNxPwLn1qvSD0cX9CE="
+        output = plugin.pem_encode_key_vault_certificate_contents(str.encode(input))
+        assert output == """-----BEGIN CERTIFICATE-----
+MIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDAS
+BgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1
+OVowFzEVMBMGA1UEAxMMS2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzM
+BMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+OXHSNbsLdmMhni0jYX09h3XlC2VJw2sGK
+eYF+xEaavXm337aZZaZyjrFBrrUl51UePaN+kVFXNlBb3N3TYpqa7KokXenJQuR+
+i9Gv9a77c0UsSsDSryxppYhKK7HvTZCpKrhVtulF5iPMswWe9np3uggfMamyIsK/
+0L7X9w9B2qN7993RR0A00nOk4H6CnkuwO77dSsD0KJsk6FyAoZBzRXDZh9+d9R76
+zCL506NcQy/jl0lCiQYwsUX73PG5pxOh02OwKwIDAQABo0swSTBHBgNVHQEEQDA+
+gBAS5AktBh0dTwCNYSHcFmRjoRgwFjEUMBIGA1UEAxMLUm9vdCBBZ2VuY3mCEAY3
+bACqAGSKEc+41KpcNfQwCQYFKw4DAh0FAANBAGqIjo2geVagzuzaZOe1ClGKhZei
+CKfWAxklaGN+qlGUbVS4IN4V1lot3VKnzabasmkEHeNxPwLn1qvSD0cX9CE=
+-----END CERTIFICATE-----"""
+
     @patch.dict(os.environ, {"VAULT_ADDR": "https://fakevaultinstance:8200"})
     @patch("azure.mgmt.network.v2022_05_01.operations.PublicIPAddressesOperations.get")
     @patch("azure.mgmt.network.v2022_05_01.operations.ApplicationGatewaysOperations.list_all")

--- a/lemur/plugins/lemur_azure/tests/test_azure_source.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_source.py
@@ -36,24 +36,6 @@ class TestAzureSource(unittest.TestCase):
     def setUp(self):
         self.azure_source = plugin.AzureSourcePlugin()
 
-    def test_pem_encode_key_vault_certificate_contents(self):
-        input = "MIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDASBgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1OVowFzEVMBMGA1UEAxMMS2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzMBMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+OXHSNbsLdmMhni0jYX09h3XlC2VJw2sGKeYF+xEaavXm337aZZaZyjrFBrrUl51UePaN+kVFXNlBb3N3TYpqa7KokXenJQuR+i9Gv9a77c0UsSsDSryxppYhKK7HvTZCpKrhVtulF5iPMswWe9np3uggfMamyIsK/0L7X9w9B2qN7993RR0A00nOk4H6CnkuwO77dSsD0KJsk6FyAoZBzRXDZh9+d9R76zCL506NcQy/jl0lCiQYwsUX73PG5pxOh02OwKwIDAQABo0swSTBHBgNVHQEEQDA+gBAS5AktBh0dTwCNYSHcFmRjoRgwFjEUMBIGA1UEAxMLUm9vdCBBZ2VuY3mCEAY3bACqAGSKEc+41KpcNfQwCQYFKw4DAh0FAANBAGqIjo2geVagzuzaZOe1ClGKhZeiCKfWAxklaGN+qlGUbVS4IN4V1lot3VKnzabasmkEHeNxPwLn1qvSD0cX9CE="
-        output = plugin.pem_encode_key_vault_certificate_contents(str.encode(input))
-        assert output == """-----BEGIN CERTIFICATE-----
-MIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDAS
-BgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1
-OVowFzEVMBMGA1UEAxMMS2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOC
-AQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzM
-BMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+OXHSNbsLdmMhni0jYX09h3XlC2VJw2sGK
-eYF+xEaavXm337aZZaZyjrFBrrUl51UePaN+kVFXNlBb3N3TYpqa7KokXenJQuR+
-i9Gv9a77c0UsSsDSryxppYhKK7HvTZCpKrhVtulF5iPMswWe9np3uggfMamyIsK/
-0L7X9w9B2qN7993RR0A00nOk4H6CnkuwO77dSsD0KJsk6FyAoZBzRXDZh9+d9R76
-zCL506NcQy/jl0lCiQYwsUX73PG5pxOh02OwKwIDAQABo0swSTBHBgNVHQEEQDA+
-gBAS5AktBh0dTwCNYSHcFmRjoRgwFjEUMBIGA1UEAxMLUm9vdCBBZ2VuY3mCEAY3
-bACqAGSKEc+41KpcNfQwCQYFKw4DAh0FAANBAGqIjo2geVagzuzaZOe1ClGKhZei
-CKfWAxklaGN+qlGUbVS4IN4V1lot3VKnzabasmkEHeNxPwLn1qvSD0cX9CE=
------END CERTIFICATE-----"""
-
     @patch.dict(os.environ, {"VAULT_ADDR": "https://fakevaultinstance:8200"})
     @patch("azure.mgmt.network.v2022_05_01.operations.PublicIPAddressesOperations.get")
     @patch("azure.mgmt.network.v2022_05_01.operations.ApplicationGatewaysOperations.list_all")


### PR DESCRIPTION
This PR contains the rest of the changes that should be required for closing [EDGE-1725](https://datadoghq.atlassian.net/browse/EDGE-1725):

- Add implementations and tests for the `get_certificates` and `get_certificate_by_name` methods in the source plugin.
- Add support for syncing the SSL policy information (e.g. supported ciphers) for endpoints.
- Fixed a minor issue around certificate naming, in particular certificate names in a key vault can't contain the character `*` when uploading wildcard certificates.

I've included some basic test cases in this PR to verify functionality and also deployed this patch to sandbox and verified that an endpoint in Azure could be synced successfully.

<img width="953" alt="Screen Shot 2022-11-01 at 6 27 05 PM" src="https://user-images.githubusercontent.com/5983714/199353716-0c30f66a-8ad4-4d11-a317-2cca90463ba6.png">

