### PR TITLE
Re-use existing Azure credential where possible

### DIFF
--- a/lemur/plugins/lemur_azure/auth.py
+++ b/lemur/plugins/lemur_azure/auth.py
@@ -22,6 +22,16 @@ class RetryableClientSecretCredential(ClientSecretCredential):
 
 
 def get_azure_credential(plugin, options):
+    """
+    Fetches a credential used for authenticating with the Azure API.
+    A new credential will be created if one does not already exist.
+    If a credential already exists and is valid, then it will be re-used.
+    When an existing credential is determined to be invalid, it will be replaced with a new one.
+
+    :param plugin: source or destination plugin
+    :param options: options set for the plugin
+    :return: an Azure credential
+    """
     if plugin.credential:
         try:
             plugin.credential.get_token("https://management.azure.com/.default")  # Try to dispense a valid token.

--- a/lemur/plugins/lemur_azure/auth.py
+++ b/lemur/plugins/lemur_azure/auth.py
@@ -24,10 +24,11 @@ class RetryableClientSecretCredential(ClientSecretCredential):
 def get_azure_credential(plugin, options):
     if plugin.credential:
         try:
-            plugin.credential.get_token()  # Try to dispense a valid token.
+            plugin.credential.get_token("https://management.azure.com/.default")  # Try to dispense a valid token.
             return plugin.credential
         except (CredentialUnavailableError, ClientAuthenticationError) as e:
-            current_app.logger.warning(f"Failed to re-use existing Azure credential, another one will attempt to be re-generated: {e}")
+            current_app.logger.warning(f"Failed to re-use existing Azure credential, another one will attempt to "
+                                       f"be re-generated: {e}")
 
     tenant = plugin.get_option("azureTenant", options)
     auth_method = plugin.get_option("authenticationMethod", options)

--- a/lemur/plugins/lemur_azure/auth.py
+++ b/lemur/plugins/lemur_azure/auth.py
@@ -1,5 +1,5 @@
-from azure.core.exceptions CredentialUnavailableError, ClientAuthenticationError
-from azure.identity import ClientSecretCredential
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity import ClientSecretCredential, CredentialUnavailableError
 from flask import current_app
 
 import hvac

--- a/lemur/plugins/lemur_azure/auth.py
+++ b/lemur/plugins/lemur_azure/auth.py
@@ -20,6 +20,9 @@ class RetryableClientSecretCredential(ClientSecretCredential):
 
 
 def get_azure_credential(plugin, options):
+    if plugin.credential:
+        return plugin.credential
+
     tenant = plugin.get_option("azureTenant", options)
     auth_method = plugin.get_option("authenticationMethod", options)
 
@@ -31,20 +34,22 @@ def get_azure_credential(plugin, options):
         # It may take up-to 10 minutes for the generated OAuth credentials to become usable due
         # to AD replication delay. To account for this, the credential will continuously
         # retry generating an access token until it succeeds or 10 minutes elapse.
-        return RetryableClientSecretCredential(
+        plugin.credential = RetryableClientSecretCredential(
             tenant_id=tenant,
             client_id=client_id,
             client_secret=client_secret,
         )
+        return plugin.credential
     elif auth_method == "azureApp":
         app_id = plugin.get_option("azureAppID", options)
         password = plugin.get_option("azurePassword", options)
 
-        return ClientSecretCredential(
+        plugin.credential = ClientSecretCredential(
             tenant_id=tenant,
             client_id=app_id,
             client_secret=password,
         )
+        return plugin.credential
 
     raise Exception("No supported way to authenticate with Azure")
 

--- a/lemur/plugins/lemur_azure/auth.py
+++ b/lemur/plugins/lemur_azure/auth.py
@@ -24,7 +24,7 @@ class RetryableClientSecretCredential(ClientSecretCredential):
 def get_azure_credential(plugin, options):
     if plugin.credential:
         try:
-            plugin.credential.get_token()
+            plugin.credential.get_token()  # Try to dispense a valid token.
             return plugin.credential
         except (CredentialUnavailableError, ClientAuthenticationError) as e:
             current_app.logger.warning(f"Failed to re-use existing Azure credential, another one will attempt to be re-generated: {e}")

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -176,6 +176,7 @@ class AzureDestinationPlugin(DestinationPlugin):
     ]
 
     def __init__(self, *args, **kwargs):
+        self.credential = None
         super(AzureDestinationPlugin, self).__init__(*args, **kwargs)
 
     def upload(self, name, body, private_key, cert_chain, options, **kwargs):
@@ -280,6 +281,7 @@ class AzureSourcePlugin(SourcePlugin):
     ]
 
     def __init__(self, *args, **kwargs):
+        self.credential = None
         super(AzureSourcePlugin, self).__init__(*args, **kwargs)
 
     def get_certificates(self, options, **kwargs):


### PR DESCRIPTION
To minimize excessive retrying slowing down source sync operations, this PR updates the Azure plugins to re-use the existing credential generated from Vault where possible.

- If the Azure credential was already generated, then it will be re-used.
- If the credential expired or a valid access token otherwise could not be dispensed, then it will be re-created.
- If a credential does not already exist, one will be created.

Closes [EDGE-1758](https://datadoghq.atlassian.net/browse/EDGE-1758).