### PR TITLE
Add region option to GCP destination plugin

### DIFF
--- a/lemur/plugins/lemur_gcp/certificates.py
+++ b/lemur/plugins/lemur_gcp/certificates.py
@@ -1,6 +1,6 @@
 from cryptography import x509
 from flask import current_app
-from google.cloud.compute_v1.services import ssl_certificates
+from google.cloud.compute_v1.services import ssl_certificates, region_ssl_certificates
 
 from lemur.common.defaults import common_name, text_to_slug
 from lemur.common.utils import parse_certificate, split_pem
@@ -52,10 +52,15 @@ def full_ca(body, cert_chain):
     return f"{body}\n{cert_chain}"
 
 
-def insert_certificate(project_id, ssl_certificate_body, credentials):
-    return ssl_certificates.SslCertificatesClient(credentials=credentials).insert(
-        project=project_id, ssl_certificate_resource=ssl_certificate_body
-    )
+def insert_certificate(project_id, ssl_certificate_body, credentials, region=None):
+    if not region:
+        ssl_certificates.SslCertificatesClient(credentials=credentials).insert(
+            project=project_id, ssl_certificate_resource=ssl_certificate_body
+        )
+    else:
+        region_ssl_certificates.RegionSslCertificatesClient(credentials=credentials).insert(
+            project=project_id, ssl_certificate_resource=ssl_certificate_body, region=region
+        )
 
 
 def fetch_all(project_id, credentials):

--- a/lemur/plugins/lemur_gcp/plugin.py
+++ b/lemur/plugins/lemur_gcp/plugin.py
@@ -24,6 +24,12 @@ class GCPDestinationPlugin(DestinationPlugin):
             "helpMessage": "GCP Project ID",
         },
         {
+            "name": "region",
+            "type": "str",
+            "helpMessage": "Scopes the certificate to a region, if supplied. If no region is given, this will "
+                           "upload certificates as a global resource."
+        },
+        {
             "name": "authenticationMethod",
             "type": "select",
             "required": True,
@@ -60,6 +66,7 @@ class GCPDestinationPlugin(DestinationPlugin):
                 self.get_option("projectID", options),
                 ssl_certificate_body,
                 credentials,
+                self.get_option("region", options),
             )
         except exceptions.AlreadyExists:
             pass

--- a/lemur/plugins/lemur_gcp/tests/test_plugin.py
+++ b/lemur/plugins/lemur_gcp/tests/test_plugin.py
@@ -67,6 +67,11 @@ options = [
         'value': 'lemur-test'
     },
     {
+        'name': 'region',
+        'type': 'str',
+        'value': 'europe-west3'
+    },
+    {
         'name': 'authenticationMethod',
         'type': 'str',
         'required': True,
@@ -94,7 +99,7 @@ def test_upload(mock_ssl_certificates, mock_credentials):
     }
 
     # assert our mocks are being called with the params we expect
-    mock_ssl_certificates.assert_called_with('lemur-test', ssl_certificate_body, token)
+    mock_ssl_certificates.assert_called_with("lemur-test", ssl_certificate_body, token, "europe-west3")
     mock_credentials.assert_called_with(plugin, options)
 
 


### PR DESCRIPTION
Add an option to the plugin so we can upload regional certificates to GCP. Regional certificates are used by internal HTTPs LBs. Since only regional certs can be used with regional HTTPs proxies and global certs with global HTTPs/SSL proxies, we need to scope the entire Destination / Source plugin operations as global or regional. For datacenters with regional resources, we will create another instance of the destination/source plugin with region set. The next PR will add support to the GCP Source plugin for scoping its operations to a region.