### PR TITLE
Support discovering Azure CDN endpoints

### DIFF
--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -31,6 +31,7 @@ from cryptography.hazmat.primitives.serialization import pkcs12
 
 
 def get_cdn_endpoints(cdn_client):
+    endpoints = []
     for profile in cdn_client.profiles.list():
         resource_group_name = resource_group_from_id(profile.id)
         for endpoint in cdn_client.endpoints.list_by_profile(
@@ -61,6 +62,8 @@ def get_cdn_endpoints(cdn_client):
                             registry_type="keyvault",
                         )
                     )
+                    endpoints.append(ep)
+    return endpoints
 
 
 def get_application_gateways(network_client):
@@ -381,11 +384,10 @@ class AzureSourcePlugin(SourcePlugin):
         endpoints = []
         for subscription in SubscriptionClient(credential=credential).subscriptions.list():
             network_client = NetworkManagementClient(credential=credential, subscription_id=subscription.subscription_id)
-            endpoints = get_application_gateways(network_client)
+            endpoints += get_application_gateways(network_client)
 
             cdn_client = CdnManagementClient(credential=credential, subscription_id=subscription.subscription_id)
-            endpoints.append(get_cdn_endpoints(cdn_client))
-
+            endpoints += get_cdn_endpoints(cdn_client)
         return endpoints
 
     @staticmethod

--- a/lemur/plugins/lemur_gcp/tests/test_plugin.py
+++ b/lemur/plugins/lemur_gcp/tests/test_plugin.py
@@ -250,8 +250,9 @@ cert4.type_ = "MANAGED"
 
 
 @mock.patch("lemur.plugins.lemur_gcp.plugin.GCPSourcePlugin.get_option")
+@mock.patch("lemur.plugins.lemur_gcp.auth.get_gcp_credentials", return_value=token)
 @mock.patch("google.cloud.compute_v1.services.ssl_certificates.SslCertificatesClient.list")
-def test_get_certificates(mock_ssl_client_list, mock_get_option):
+def test_get_certificates(mock_ssl_client_list, mock_credentials, mock_get_option):
     from lemur.plugins.lemur_gcp.plugin import GCPSourcePlugin
     mock_ssl_client_list.return_value = [cert1, cert2, cert3, cert4]
     mock_get_option.side_effect = ["lemur-test", None]
@@ -276,8 +277,9 @@ def test_get_certificates(mock_ssl_client_list, mock_get_option):
 
 
 @mock.patch("lemur.plugins.lemur_gcp.plugin.GCPSourcePlugin.get_option")
+@mock.patch("lemur.plugins.lemur_gcp.auth.get_gcp_credentials", return_value=token)
 @mock.patch("google.cloud.compute_v1.services.region_ssl_certificates.RegionSslCertificatesClient.list")
-def test_get_regional_certificates(mock_ssl_client_list, mock_get_option):
+def test_get_regional_certificates(mock_ssl_client_list, mock_credentials, mock_get_option):
     from lemur.plugins.lemur_gcp.plugin import GCPSourcePlugin
     mock_ssl_client_list.return_value = [cert1, cert2, cert3, cert4]
     mock_get_option.side_effect = ["lemur-test", "europe-west3"]

--- a/lemur/plugins/lemur_gcp/tests/test_plugin.py
+++ b/lemur/plugins/lemur_gcp/tests/test_plugin.py
@@ -250,9 +250,8 @@ cert4.type_ = "MANAGED"
 
 
 @mock.patch("lemur.plugins.lemur_gcp.plugin.GCPSourcePlugin.get_option")
-@mock.patch("lemur.plugins.lemur_gcp.auth.get_gcp_credentials", return_value=token)
 @mock.patch("google.cloud.compute_v1.services.ssl_certificates.SslCertificatesClient.list")
-def test_get_certificates(mock_ssl_client_list, mock_credentials, mock_get_option):
+def test_get_certificates(mock_ssl_client_list, mock_get_option):
     from lemur.plugins.lemur_gcp.plugin import GCPSourcePlugin
     mock_ssl_client_list.return_value = [cert1, cert2, cert3, cert4]
     mock_get_option.side_effect = ["lemur-test", None]
@@ -277,9 +276,8 @@ def test_get_certificates(mock_ssl_client_list, mock_credentials, mock_get_optio
 
 
 @mock.patch("lemur.plugins.lemur_gcp.plugin.GCPSourcePlugin.get_option")
-@mock.patch("lemur.plugins.lemur_gcp.auth.get_gcp_credentials", return_value=token)
 @mock.patch("google.cloud.compute_v1.services.region_ssl_certificates.RegionSslCertificatesClient.list")
-def test_get_regional_certificates(mock_ssl_client_list, mock_credentials, mock_get_option):
+def test_get_regional_certificates(mock_ssl_client_list, mock_get_option):
     from lemur.plugins.lemur_gcp.plugin import GCPSourcePlugin
     mock_ssl_client_list.return_value = [cert1, cert2, cert3, cert4]
     mock_get_option.side_effect = ["lemur-test", "europe-west3"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 # Run `make up-reqs` to update pinned dependencies in requirement text files
 
 acme
+azure-mgmt-cdn
 azure-mgmt-network
 azure-mgmt-subscription
 azure-identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ azure-common==1.1.28
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
+    #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 azure-core==1.26.0
@@ -49,8 +50,11 @@ azure-keyvault-keys==4.7.0
     # via azure-keyvault
 azure-keyvault-secrets==4.6.0
     # via azure-keyvault
+azure-mgmt-cdn==12.0.0
+    # via -r requirements.in
 azure-mgmt-core==1.3.2
     # via
+    #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 azure-mgmt-network==22.1.0
@@ -254,6 +258,7 @@ msrest==0.7.1
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
+    #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 ndg-httpsclient==0.5.1


### PR DESCRIPTION
At a high level this change adds support for syncing CDN endpoints in the Azure source plugin. This isn't required for automated rotations but gives us additional visibility into endpoints in our Azure environments that may or may not be using Lemur certificates.
Closes [EDGE-1784](https://datadoghq.atlassian.net/browse/EDGE-1784).