### PR TITLE
Bump cryptography and openssl

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -54,7 +54,7 @@ configobj==5.0.6
     # via certbot
 coverage==6.4.1
     # via -r requirements-tests.in
-cryptography==37.0.2
+cryptography==39.0.0
     # via
     #   acme
     #   certbot
@@ -195,7 +195,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.4.0
     # via -r requirements-tests.in
-pyopenssl==22.0.0
+pyopenssl==23.0.0
     # via
     #   acme
     #   josepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,7 +120,7 @@ configargparse==1.5.3
     # via certbot
 configobj==5.0.6
     # via certbot
-cryptography==37.0.2
+cryptography==39.0.0
     # via
     #   -r requirements.in
     #   acme
@@ -312,7 +312,7 @@ pyjwt[crypto]==2.4.0
     #   msal
 pynacl==1.5.0
     # via paramiko
-pyopenssl==22.0.0
+pyopenssl==23.0.0
     # via
     #   -r requirements.in
     #   acme


### PR DESCRIPTION
Bumps cryptography and openssl dependencies to resolve CVE-2022-3602 and CVE-2022-3786 being flagged by our vulnerability scanners. 