### PR TITLE
Update the docker base image

### DIFF
--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,5 @@
 # Lemur Builder
-FROM registry.ddbuild.io/base:focal as builder
+FROM gbi-ubuntu_2004 as builder
 
 ARG CI_COMMIT_SHA
 
@@ -43,7 +43,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM registry.ddbuild.io/base:focal
+FROM gbi-ubuntu_2004
 
 USER root
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,5 @@
 # Lemur Builder
-FROM gbi-ubuntu_2004 as builder
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2004 as builder
 
 ARG CI_COMMIT_SHA
 
@@ -43,7 +43,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM gbi-ubuntu_2004
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2004
 
 USER root
 


### PR DESCRIPTION
This PR updates the base Docker base image to the GBI for Ubuntu focal. The strategy was to let this image "soak" on staging for a while before promoting. After having it run on the Sandbox instance for >2weeks Im confident with promoting this. 
The base metrics for the app (CPU and Memory) has stayed consistent with the baseline on the previous image. Im also confident that none of the core functionality of the app has been affected because we have been doing testing to the Adapter while this image has been on Sandbox. 

