### PR TITLE
Use more stable naming for Azure destination plugin

### DIFF
--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -19,8 +19,8 @@ from azure.mgmt.subscription import SubscriptionClient
 from azure.mgmt.cdn.models import UserManagedHttpsParameters
 from azure.mgmt.network.models import ApplicationGatewaySslPolicyName, ApplicationGatewaySslPolicyType, ApplicationGatewaySslCipherSuite
 
-from lemur.common.defaults import common_name, issuer, bitstrength
-from lemur.common.utils import parse_certificate, parse_private_key, check_validation
+from lemur.common.defaults import common_name, bitstrength
+from lemur.common.utils import parse_certificate, parse_private_key, check_validation, get_key_type_from_certificate
 from lemur.extensions import metrics
 from lemur.plugins.bases import DestinationPlugin, SourcePlugin
 from lemur.plugins.lemur_azure.auth import get_azure_credential

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -269,7 +269,7 @@ class AzureDestinationPlugin(DestinationPlugin):
             ca_vendor=ca_vendor,
             key_type=key_type,
         )
-        
+
         certificate_client = CertificateClient(
             credential=get_azure_credential(self, options),
             vault_url=self.get_option("azureKeyVaultUrl", options),

--- a/lemur/plugins/lemur_azure/tests/test_azure_dest.py
+++ b/lemur/plugins/lemur_azure/tests/test_azure_dest.py
@@ -107,7 +107,7 @@ class TestAzureDestination(unittest.TestCase):
 
         def _assert_certificate_imported():
             import_certificate_mock.assert_called_with(
-                certificate_name="localhost-LocalCA",
+                certificate_name="localhost-Sirferl-RSA2048",
                 certificate_bytes=ANY,
                 enabled=True,
                 policy=ANY,


### PR DESCRIPTION
In [some situations](https://knowledge.digicert.com/generalinformation/digicert-root-and-intermediate-ca-certificate-updates-2023.html), certificate authorities may proactively begin issuing certificates using a new CA certificate. When this occurs with the current implementation of the destination plugin, the name of the renewed certificate uploaded to Key Vault will change. This is an undesirable side effect because it forces operators to reconfigure their Azure endpoints (CDNs, Application Gateways, etc.) to use the new Key Vault path that the renewed certificate was uploaded to.

To circumvent this issue, this PR updates the certificate naming convention so that it is agnostic to the issuing CA certificate. It does this by changing the certificate naming logic to parse the vendor name (e.g. `DigiCert` or `Sectigo`) from the CA certificate where possible. Similarly, this PR also ensures that certificate names when uploaded will continue to convey whether the certificate is of type `ECC` or `RSA` and the corresponding key size, but instead using naming consistent with Lemur such as `ECCSECP384R1`, `ECCPRIME256V1`, `RSA2048`, and `RSA4096` for example. 

