### PR TITLE
bump redis for version 4.4.4

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -228,7 +228,7 @@ pyyaml==6.0
     #   bandit
     #   cfn-lint
     #   moto
-redis==4.4.2
+redis==4.4.4
     # via
     #   -r requirements-tests.in
     #   fakeredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -378,7 +378,7 @@ pyyaml==6.0
     # via
     #   -r requirements.in
     #   cloudflare
-redis==4.4.2
+redis==4.4.4
     # via
     #   -r requirements.in
     #   celery


### PR DESCRIPTION
Bump redis package by 2 minor versions to v4.4.4

Release [notes for 4.4.3](https://github.com/redis/redis-py/releases/tag/v4.4.3) and [4.4.4](https://github.com/redis/redis-py/releases/tag/v4.4.4)