### PR TITLE
Don't include root certificates returned by Sectigo in CA bundle

### DIFF
--- a/lemur/plugins/lemur_sectigo/plugin.py
+++ b/lemur/plugins/lemur_sectigo/plugin.py
@@ -4,7 +4,7 @@ import requests
 
 from cert_manager import Client, Organization, Pending, SSL
 from flask import current_app
-from lemur.common.utils import validate_conf
+from lemur.common.utils import validate_conf, parse_certificate
 from lemur.plugins.bases import IssuerPlugin
 from retrying import retry
 
@@ -119,10 +119,11 @@ def _collect_certificate(cert_id, ssl_client):
         current_app.logger.info({"message": "Collecting certificate from Sectigo..."})
         cert_pem = ssl_client.collect(cert_id=cert_id, cert_format="pem")
         parts = pem.parse(cert_pem.encode("utf-8"))
-        ca_bundle = [str(c) for c in parts[:-1]]
-        ca_bundle.reverse()
-        ca_bundle = "".join(ca_bundle)
-        issued_cert = str(parts[-1])
+        parts = [str(c) for c in parts]
+        issued_cert = parts.pop()
+        parts.reverse()
+        # Don't include any self-signed (anchor/root CA) certs in the bundle
+        ca_bundle = "".join([c for c in parts if parse_certificate(c).issuer != parse_certificate(c).subject])
 
         return (
             issued_cert,

--- a/lemur/plugins/lemur_sectigo/tests/test_plugin.py
+++ b/lemur/plugins/lemur_sectigo/tests/test_plugin.py
@@ -94,7 +94,7 @@ class TestSectigoIssuerPlugin(TestCase):
                     },
                 )
                 assert WILDCARD_CERT_STR == cert_pem
-                assert (INTERMEDIATE_CERT_STR + ROOTCA_CERT_STR) == ca_bundle
+                assert INTERMEDIATE_CERT_STR == ca_bundle
                 assert 3000 == cert_id
 
             with self.subTest(case="create certificates with unsupported terms"):
@@ -106,7 +106,7 @@ class TestSectigoIssuerPlugin(TestCase):
                     },
                 )
                 assert WILDCARD_CERT_STR == cert_pem
-                assert (INTERMEDIATE_CERT_STR + ROOTCA_CERT_STR) == ca_bundle
+                assert INTERMEDIATE_CERT_STR == ca_bundle
                 assert 3000 == cert_id
 
                 cert_pem, ca_bundle, cert_id = plugin.create_certificate(
@@ -117,7 +117,7 @@ class TestSectigoIssuerPlugin(TestCase):
                     },
                 )
                 assert WILDCARD_CERT_STR == cert_pem
-                assert (INTERMEDIATE_CERT_STR + ROOTCA_CERT_STR) == ca_bundle
+                assert INTERMEDIATE_CERT_STR == ca_bundle
                 assert 3000 == cert_id
 
                 cert_pem, ca_bundle, cert_id = plugin.create_certificate(
@@ -128,7 +128,7 @@ class TestSectigoIssuerPlugin(TestCase):
                     },
                 )
                 assert WILDCARD_CERT_STR == cert_pem
-                assert (INTERMEDIATE_CERT_STR + ROOTCA_CERT_STR) == ca_bundle
+                assert INTERMEDIATE_CERT_STR == ca_bundle
                 assert 3000 == cert_id
 
     def test_determine_certificate_term(self):


### PR DESCRIPTION
[EDGE-2152](https://datadoghq.atlassian.net/browse/EDGE-2152) We began including the root certificate in the Sectigo chain on Feb 9, 2023, and this caused trouble for JPMorgan Chase's reverse proxy config ([EDGES-11](https://datadoghq.atlassian.net/browse/EDGES-11)).

Because we didn't previously include the root, I'm comfortable reverting to this configuration. In general, the server sending the root is optional, and clients are supposed to have roots in their trust store prior to connecting to the server (and specifically should **not** trust any root provided by the server itself.)

JPMC's issue comes from the fact that when their MITM proxy re-signs certificates, it does so at the signature strength of the weakest signature algorithm in the chain. Even though our Sectigo cert chains up to a cert with a stronger sig alg than SHA1, the presence of the `AAA Certificate Services` root sent by the server takes precedence. This behavior is admittedly a weird edge case, but the combination of not including the root being:

1. the more correct behavior
2. the behavior prior to Feb 9, 2023
3. less likely to cause issues with middleboxes

makes me want to make this change.