### PR TITLE
Emitting source based last_success metric to track certificate rotation success by source

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -152,7 +152,7 @@ def report_celery_last_success_metrics():
 
         kwargs = t.get("kwargs")
         if "source" in kwargs:
-            source = kwargs[source]
+            source = kwargs["source"]
             last_success = int(red.get(f"{source}.last_success") or 0)
             metrics.send(
                 f"{source}.time_since_last_success", "gauge", current_time - last_success
@@ -192,7 +192,7 @@ def report_successful_task(**kwargs):
         red.set(f"{tags['task_name']}.last_success", int(time.time()))
 
         if "source" in kwargs:
-            source = kwargs[source]
+            source = kwargs["source"]
             red.set(f"{source}.last_success", int(time.time()))
             
         metrics.send("celery.successful_task", "TIMER", 1, metric_tags=tags)

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -674,6 +674,8 @@ def certificate_rotate(**kwargs):
     current_app.logger.debug(log_data)
     metrics.send(f"{function}.success", "counter", 1, metric_tags=metric_tags)
 
+    # When doing rotation by source we want to emit a `time_since_last_success` metric for the given source.
+    # as this source information is only available via the kwargs for this task we have to store the last_success time for the source here to access later
     if source:
         red.set(f"{function}_{source}.last_success", int(time.time()))
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -146,12 +146,12 @@ def report_celery_last_success_metrics():
     for _, t in schedule.items():
         task = t.get("task")
 
-        tags = {}
+        metric_tags = {}
         kwargs = t.get("kwargs")
         if kwargs is not None and "source" in kwargs:
             source = kwargs["source"]
             last_success = int(red.get(f"{source}.last_success") or 0)
-            tags["source_name"] = source
+            metric_tags["source_name"] = source
         else:
             last_success = int(red.get(f"{task}.last_success") or 0)
 
@@ -159,7 +159,7 @@ def report_celery_last_success_metrics():
             f"{task}.time_since_last_success",
             "gauge",
             current_time - last_success,
-            tags=tags
+            metric_tags=metric_tags
         )
 
     red.set(

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -148,7 +148,7 @@ def report_celery_last_success_metrics():
 
         tags = {}
         kwargs = t.get("kwargs")
-        if not kwargs is None and "source" in kwargs:
+        if kwargs is not None and "source" in kwargs:
             source = kwargs["source"]
             last_success = int(red.get(f"{source}.last_success") or 0)
             tags["source_name"] = source
@@ -156,9 +156,9 @@ def report_celery_last_success_metrics():
             last_success = int(red.get(f"{task}.last_success") or 0)
 
         metrics.send(
-            f"{task}.time_since_last_success", 
+            f"{task}.time_since_last_success",
             "gauge",
-            current_time - last_success, 
+            current_time - last_success,
             tags=tags
         )
 
@@ -195,7 +195,7 @@ def report_successful_task(**kwargs):
         tags = get_celery_request_tags(**kwargs)
         red.set(f"{tags['task_name']}.last_success", int(time.time()))
 
-        if not kwargs is None and "source" in kwargs:
+        if kwargs is not None and "source" in kwargs:
             source = kwargs["source"]
             red.set(f"{source}.last_success", int(time.time()))
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -195,11 +195,6 @@ def report_successful_task(**kwargs):
     with flask_app.app_context():
         tags = get_celery_request_tags(**kwargs)
         red.set(f"{tags['task_name']}.last_success", int(time.time()))
-
-        if kwargs is not None and "source" in kwargs:
-            source = kwargs["source"]
-            red.set(f"{tags['task_name']}_{source}.last_success", int(time.time()))
-
         metrics.send("celery.successful_task", "TIMER", 1, metric_tags=tags)
 
 
@@ -678,6 +673,10 @@ def certificate_rotate(**kwargs):
     log_data["message"] = "rotation completed"
     current_app.logger.debug(log_data)
     metrics.send(f"{function}.success", "counter", 1, metric_tags=metric_tags)
+
+    if source:
+        red.set(f"{function}_{source}.last_success", int(time.time()))
+
     return log_data
 
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -150,17 +150,18 @@ def report_celery_last_success_metrics():
         kwargs = t.get("kwargs")
         if kwargs is not None and "source" in kwargs:
             source = kwargs["source"]
-            last_success = int(red.get(f"{source}.last_success") or 0)
+            last_success = int(red.get(f"{task}_{source}.last_success") or 0)
             metric_tags["source_name"] = source
         else:
             last_success = int(red.get(f"{task}.last_success") or 0)
 
-        metrics.send(
-            f"{task}.time_since_last_success",
-            "gauge",
-            current_time - last_success,
-            metric_tags=metric_tags
-        )
+        if last_success != 0:
+            metrics.send(
+                f"{task}.time_since_last_success",
+                "gauge",
+                current_time - last_success,
+                metric_tags=metric_tags
+            )
 
     red.set(
         f"{function}.last_success", int(time.time())
@@ -197,7 +198,7 @@ def report_successful_task(**kwargs):
 
         if kwargs is not None and "source" in kwargs:
             source = kwargs["source"]
-            red.set(f"{source}.last_success", int(time.time()))
+            red.set(f"{tags['task_name']}_{source}.last_success", int(time.time()))
 
         metrics.send("celery.successful_task", "TIMER", 1, metric_tags=tags)
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -194,7 +194,7 @@ def report_successful_task(**kwargs):
         if "source" in kwargs:
             source = kwargs["source"]
             red.set(f"{source}.last_success", int(time.time()))
-            
+
         metrics.send("celery.successful_task", "TIMER", 1, metric_tags=tags)
 
 


### PR DESCRIPTION
The current Lemur implementation emits a last_success metric per task based on the name of the function the task invokes.  Source based rotation was recently added to stagger when we rotate certificates in different sites, but this had the side effect of having each site's task emitting metrics for last_success that had no differentiating information based on the site.  This could lead to one site's rotation failing for an extended period but having last_success metrics still report healthy rotation when other sites could rotate correctly.  This PR emits these metrics on a per source basis as well now to correctly track last_success on a per site basis.