### PR TITLE
Skipping duplicate account number validation for destination plugins without an account number

### DIFF
--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -483,7 +483,7 @@ def create(**kwargs):
             account = get_plugin_option("accountNumber", dest.options)
 
             # only AWS destinations have an account number, so we can skip this validation if an account number is not found
-            if account != None:
+            if account is not None:
                 if account in plugin_accounts:
                     raise Exception(f"Too many destinations for plugin {dest.plugin_name} and account {account}")
                 plugin_accounts[account] = True

--- a/lemur/certificates/service.py
+++ b/lemur/certificates/service.py
@@ -481,9 +481,12 @@ def create(**kwargs):
         for dest in kwargs["destinations"]:
             plugin_accounts = dest_plugin_accounts.setdefault(dest.plugin_name, {})
             account = get_plugin_option("accountNumber", dest.options)
-            if account in plugin_accounts:
-                raise Exception(f"Too many destinations for plugin {dest.plugin_name} and account {account}")
-            plugin_accounts[account] = True
+
+            # only AWS destinations have an account number, so we can skip this validation if an account number is not found
+            if account != None:
+                if account in plugin_accounts:
+                    raise Exception(f"Too many destinations for plugin {dest.plugin_name} and account {account}")
+                plugin_accounts[account] = True
 
     try:
         cert_body, private_key, cert_chain, external_id, csr = mint(**kwargs)


### PR DESCRIPTION
The base destination plugin implementation assumes that all destination plugins will have an account number.  This is very AWS centric and doesn't apply to non-AWS plugins.  This results in some validation code that attempts to read the account number from non-aws destination plugins, populates None as the value, and incorrectly uses None as a dictionary key breaking the validation.

By bypassing this validation when there is no account number we can scope the change to AWS only without major refactors to the code.  In the future we may want to make some more extensible validation in case we want to have other inter-destination validations that are provider specific.