### PR TITLE
Increasing Lemur Dependency Versions to Address Vulnerabilities

### DIFF
--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -11,7 +11,7 @@ celery[redis]
 certbot
 certsrv
 CloudFlare
-cryptography >= 41.0.4 # Required to avoid vulnerability in previous version (VULN-4474)
+cryptography >= 41.0.6 # Required to avoid vulnerability in previous version (VULN-5135)
 dnspython3
 dyn
 Flask <= 1.1.2 # similar to Flask-Migrate
@@ -33,8 +33,9 @@ logmatic-python
 marshmallow-sqlalchemy == 0.23.1 #related to the marshmallow issue (to avoid conflicts, as newer versions require marshmallow>=3.0.0)
 sqlalchemy < 1.4.0 # ImportError: cannot import name '_ColumnEntity' https://github.com/sqlalchemy/sqlalchemy/issues/6226
 marshmallow<2.21.1 #schema duplicate issues https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/121
-paramiko  # required for the SFTP destination plugin
+paramiko >= 3.4.0 # required for the SFTP destination plugin
 pem
+pycryptodomex >= 3.19.1 # Required to address vulnerability in older version (VULN-5325)
 pyjks >= 19 # pyjks < 19 depends on pycryptodome, which conflicts with dyn's usage of pycrypto
 pyjwt
 pyOpenSSL
@@ -45,7 +46,7 @@ SQLAlchemy-Utils
 tabulate
 urllib3 == 1.26.18 # urllib3 is used by 'requests' package. Version restriction is required to avoid vulnerability in previous version (VULN-4806)
 vine
-werkzeug < 2.1.0 # requires a newer version of Flask
+werkzeug >= 3.0.1 # required to address vulnerability in older version (VULN-4844)
 xmltodict
 # Test requirements are needed to allow test docs to build
 -r requirements-tests.txt

--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -46,7 +46,7 @@ SQLAlchemy-Utils
 tabulate
 urllib3 == 1.26.18 # urllib3 is used by 'requests' package. Version restriction is required to avoid vulnerability in previous version (VULN-4806)
 vine
-werkzeug >= 3.0.1 # required to address vulnerability in older version (VULN-4844)
+werkzeug < 2.1.0 # requires a newer version of Flask
 xmltodict
 # Test requirements are needed to allow test docs to build
 -r requirements-tests.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -129,7 +129,7 @@ configobj==5.0.8
     #   certbot
 coverage==7.3.2
     # via -r requirements-tests.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt
@@ -255,7 +255,7 @@ itsdangerous==2.0.1
     #   flask
 javaobj-py3==0.4.3
     # via pyjks
-jinja2==3.0.3
+jinja2==3.1.3
     # via
     #   -r requirements-tests.txt
     #   flask
@@ -322,6 +322,7 @@ markupsafe==2.1.3
     #   -r requirements-tests.txt
     #   jinja2
     #   mako
+    #   werkzeug
 marshmallow==2.21.0
     # via
     #   -r requirements-docs.in
@@ -336,9 +337,7 @@ mdurl==0.1.2
     #   -r requirements-tests.txt
     #   markdown-it-py
 moto[all]==4.2.6
-    # via
-    #   -r requirements-tests.txt
-    #   moto
+    # via -r requirements-tests.txt
 mpmath==1.3.0
     # via
     #   -r requirements-tests.txt
@@ -373,7 +372,7 @@ packaging==23.2
     #   gunicorn
     #   pytest
     #   sphinx
-paramiko==3.3.1
+paramiko==3.4.0
     # via -r requirements-docs.in
 parsedatetime==2.6
     # via
@@ -418,8 +417,10 @@ pycparser==2.21
     # via
     #   -r requirements-tests.txt
     #   cffi
-pycryptodomex==3.19.0
-    # via pyjks
+pycryptodomex==3.20.0
+    # via
+    #   -r requirements-docs.in
+    #   pyjks
 pydantic==2.4.2
     # via
     #   -r requirements-tests.txt
@@ -481,7 +482,6 @@ python-jose[cryptography]==3.3.0
     # via
     #   -r requirements-tests.txt
     #   moto
-    #   python-jose
 python-json-logger==2.0.7
     # via logmatic-python
 pytz==2023.3.post1
@@ -669,7 +669,7 @@ websocket-client==1.6.4
     # via
     #   -r requirements-tests.txt
     #   docker
-werkzeug==2.0.3
+werkzeug==3.0.1
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -255,7 +255,7 @@ itsdangerous==2.0.1
     #   flask
 javaobj-py3==0.4.3
     # via pyjks
-jinja2==3.1.3
+jinja2==3.0.3
     # via
     #   -r requirements-tests.txt
     #   flask
@@ -322,7 +322,6 @@ markupsafe==2.1.3
     #   -r requirements-tests.txt
     #   jinja2
     #   mako
-    #   werkzeug
 marshmallow==2.21.0
     # via
     #   -r requirements-docs.in
@@ -669,7 +668,7 @@ websocket-client==1.6.4
     # via
     #   -r requirements-tests.txt
     #   docker
-werkzeug==3.0.1
+werkzeug==2.0.3
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt

--- a/requirements-tests.in
+++ b/requirements-tests.in
@@ -3,7 +3,7 @@ bandit
 black
 coverage
 certbot
-cryptography >= 41.0.4 # Required to avoid vulnerability in previous version (VULN-4474)
+cryptography >= 41.0.6 # Required to avoid vulnerability in previous version (VULN-5135)
 factory-boy
 Faker
 fakeredis
@@ -11,7 +11,7 @@ flask <= 1.1.2 # similar to Flask-Migrate
 flask-migrate <= 2.7.0 #mirgration to Flask CLI required, https://github.com/miguelgrinberg/Flask-Migrate/issues/407
 freezegun
 itsdangerous < 2.1.0 # requires Flask 2.0.3
-jinja2 < 3.1.0 # requires a newer version of Flask
+jinja2 >= 3.1.3 # required to address vulnerability in older version (VULN-5368)
 jsonschema ~= 3.0 # Required for cert orchestration adapter.
 marshmallow-sqlalchemy == 0.23.1 #related to the marshmallow issue (to avoid conflicts)
 marshmallow<2.21.1 #schema duplicate issues https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/121
@@ -26,4 +26,4 @@ requests-mock
 sqlalchemy < 1.4.0 # ImportError: cannot import name '_ColumnEntity' https://github.com/sqlalchemy/sqlalchemy/issues/6226
 urllib3 == 1.26.18 # urllib3 is used by 'requests' package. Version restriction is required to avoid vulnerability in previous version (VULN-4806)
 pyyaml>=4.2b1
-werkzeug < 2.1.0 # requires a newer version of Flask
+werkzeug >= 3.0.1 # required to address vulnerability in older version (VULN-4844)

--- a/requirements-tests.in
+++ b/requirements-tests.in
@@ -11,7 +11,7 @@ flask <= 1.1.2 # similar to Flask-Migrate
 flask-migrate <= 2.7.0 #mirgration to Flask CLI required, https://github.com/miguelgrinberg/Flask-Migrate/issues/407
 freezegun
 itsdangerous < 2.1.0 # requires Flask 2.0.3
-jinja2 >= 3.1.3 # required to address vulnerability in older version (VULN-5368)
+jinja2 < 3.1.0 # requires a newer version of Flask
 jsonschema ~= 3.0 # Required for cert orchestration adapter.
 marshmallow-sqlalchemy == 0.23.1 #related to the marshmallow issue (to avoid conflicts)
 marshmallow<2.21.1 #schema duplicate issues https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/121
@@ -26,4 +26,4 @@ requests-mock
 sqlalchemy < 1.4.0 # ImportError: cannot import name '_ColumnEntity' https://github.com/sqlalchemy/sqlalchemy/issues/6226
 urllib3 == 1.26.18 # urllib3 is used by 'requests' package. Version restriction is required to avoid vulnerability in previous version (VULN-4806)
 pyyaml>=4.2b1
-werkzeug >= 3.0.1 # required to address vulnerability in older version (VULN-4844)
+werkzeug < 2.1.0 # requires a newer version of Flask

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -55,7 +55,7 @@ configobj==5.0.8
     # via certbot
 coverage==7.3.2
     # via -r requirements-tests.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements-tests.in
     #   acme
@@ -112,7 +112,7 @@ itsdangerous==2.0.1
     # via
     #   -r requirements-tests.in
     #   flask
-jinja2==3.0.3
+jinja2==3.1.3
     # via
     #   -r requirements-tests.in
     #   flask
@@ -152,6 +152,7 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
+    #   werkzeug
 marshmallow==2.21.0
     # via
     #   -r requirements-tests.in
@@ -161,9 +162,7 @@ marshmallow-sqlalchemy==0.23.1
 mdurl==0.1.2
     # via markdown-it-py
 moto[all]==4.2.6
-    # via
-    #   -r requirements-tests.in
-    #   moto
+    # via -r requirements-tests.in
 mpmath==1.3.0
     # via sympy
 multipart==0.2.4
@@ -240,9 +239,7 @@ python-dateutil==2.8.2
     #   freezegun
     #   moto
 python-jose[cryptography]==3.3.0
-    # via
-    #   moto
-    #   python-jose
+    # via moto
 pytz==2023.3.post1
     # via
     #   acme
@@ -327,7 +324,7 @@ urllib3==1.26.18
     #   responses
 websocket-client==1.6.4
     # via docker
-werkzeug==2.0.3
+werkzeug==3.0.1
     # via
     #   -r requirements-tests.in
     #   flask

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -112,7 +112,7 @@ itsdangerous==2.0.1
     # via
     #   -r requirements-tests.in
     #   flask
-jinja2==3.1.3
+jinja2==3.0.3
     # via
     #   -r requirements-tests.in
     #   flask
@@ -152,7 +152,6 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
-    #   werkzeug
 marshmallow==2.21.0
     # via
     #   -r requirements-tests.in
@@ -324,7 +323,7 @@ urllib3==1.26.18
     #   responses
 websocket-client==1.6.4
     # via docker
-werkzeug==3.0.1
+werkzeug==2.0.3
     # via
     #   -r requirements-tests.in
     #   flask

--- a/requirements.in
+++ b/requirements.in
@@ -42,7 +42,7 @@ grpcio-status == 1.47.0 # Required for cert orchestration adapter.
 hvac # required for the vault destination plugin
 inflection
 itsdangerous < 2.1.0 # requires Flask 2.0.3
-jinja2 >= 3.1.3 # required to address vulnerability in older version (VULN-5368)
+jinja2 < 3.1.0 # requires a newer version of Flask
 jsonschema ~= 3.0 # Required for cert orchestration adapter.
 lockfile
 logmatic-python
@@ -69,5 +69,5 @@ sqlalchemy < 1.4.0 # ImportError: cannot import name '_ColumnEntity' https://git
 tabulate
 urllib3 == 1.26.18 # urllib3 is used by 'requests' package. Version restriction is required to avoid vulnerability in previous version (VULN-4806)
 validators
-werkzeug >= 3.0.1 # required to address vulnerability in older version (VULN-4844)
+werkzeug < 2.1.0 # requires a newer version of Flask
 xmltodict

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ cert_manager
 certsrv
 https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.5-py3-none-any.whl
 CloudFlare
-cryptography >= 41.0.4 # Required to avoid vulnerability in previous version (VULN-4474)
+cryptography >= 41.0.6 # Required to avoid vulnerability in previous version (VULN-5135)
 deprecated
 dnspython3
 ddtrace == 0.53.0 # Required for cert orchestration adapter.
@@ -42,17 +42,18 @@ grpcio-status == 1.47.0 # Required for cert orchestration adapter.
 hvac # required for the vault destination plugin
 inflection
 itsdangerous < 2.1.0 # requires Flask 2.0.3
-jinja2 < 3.1.0 # requires a newer version of Flask
+jinja2 >= 3.1.3 # required to address vulnerability in older version (VULN-5368)
 jsonschema ~= 3.0 # Required for cert orchestration adapter.
 lockfile
 logmatic-python
 marshmallow-sqlalchemy == 0.23.1 #related to the marshmallow issue (to avoid conflicts)
 marshmallow<2.21.1 #schema duplicate issues https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/121
 ndg-httpsclient
-paramiko  # required for the SFTP destination plugin
+paramiko >= 3.4.0 # required for the SFTP destination plugin
 pem
 protobuf == 3.20.2 # Required for cert orchestration adapter.
 psycopg2
+pycryptodomex >= 3.19.1 # Required to address vulnerability in older version (VULN-5325)
 pyjks >= 19 # pyjks < 19 depends on pycryptodome, which conflicts with dyn's usage of pycrypto
 pyjwt
 pyOpenSSL
@@ -68,5 +69,5 @@ sqlalchemy < 1.4.0 # ImportError: cannot import name '_ColumnEntity' https://git
 tabulate
 urllib3 == 1.26.18 # urllib3 is used by 'requests' package. Version restriction is required to avoid vulnerability in previous version (VULN-4806)
 validators
-werkzeug < 2.1.0 # requires a newer version of Flask
+werkzeug >= 3.0.1 # required to address vulnerability in older version (VULN-4844)
 xmltodict

--- a/requirements.txt
+++ b/requirements.txt
@@ -235,7 +235,7 @@ itsdangerous==2.0.1
     #   flask
 javaobj-py3==0.4.3
     # via pyjks
-jinja2==3.1.3
+jinja2==3.0.3
     # via
     #   -r requirements.in
     #   flask
@@ -263,7 +263,6 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
-    #   werkzeug
 marshmallow==2.21.0
     # via
     #   -r requirements.in
@@ -464,7 +463,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.8
     # via prompt-toolkit
-werkzeug==3.0.1
+werkzeug==2.0.3
     # via
     #   -r requirements.in
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,7 +130,7 @@ configargparse==1.7
     # via certbot
 configobj==5.0.8
     # via certbot
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   acme
@@ -235,7 +235,7 @@ itsdangerous==2.0.1
     #   flask
 javaobj-py3==0.4.3
     # via pyjks
-jinja2==3.0.3
+jinja2==3.1.3
     # via
     #   -r requirements.in
     #   flask
@@ -263,6 +263,7 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
+    #   werkzeug
 marshmallow==2.21.0
     # via
     #   -r requirements.in
@@ -287,7 +288,7 @@ packaging==23.2
     # via
     #   ddtrace
     #   gunicorn
-paramiko==3.3.1
+paramiko==3.4.0
     # via -r requirements.in
 parsedatetime==2.6
     # via certbot
@@ -325,8 +326,10 @@ pyasn1-modules==0.3.0
     #   python-ldap
 pycparser==2.21
     # via cffi
-pycryptodomex==3.19.0
-    # via pyjks
+pycryptodomex==3.20.0
+    # via
+    #   -r requirements.in
+    #   pyjks
 pyjks==20.0.0
     # via -r requirements.in
 pyjwt[crypto]==2.8.0
@@ -461,7 +464,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.8
     # via prompt-toolkit
-werkzeug==2.0.3
+werkzeug==3.0.1
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
Addressing vulnerabilities found in cert_orchestration_adapter, will import new dependencies there after merge.

Package Name: pycryptodomex
Vulnerable Version[s] < 3.19.1
Patched Version: 3.19.1

Package Name: paramiko
Vulnerable Version[s] < 3.4.0
Patched Version: 3.4.0

Package Name: cryptography
Vulnerable Version[s] >= 3.1, < 41.0.6
Patched Version: 41.0.6

Package Name: urllib3
Vulnerable Version[s] <= 1.26.17
Patched Version: 1.26.18