### PR TITLE
Ensure prod image is properly tagged

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,7 @@ build-prod-image:
     - docker buildx build
       --label target=staging
       --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA}
-      --tag registry.ddbuild.io/lemur:v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
+      --tag registry.ddbuild.io/lemur:$CI_COMMIT_TAG
       --metadata-file ${METADATA_FILE}
       --push
       .


### PR DESCRIPTION
Otherwise image signing will fail e.g. with an error such as:

```
Error: artifact reference argument registry.ddbuild.io/lemur:1.0.0-dd.23 does not match image.name field registry.ddbuild.io/lemur:v30311121-b3bb0b49 in Docker metadata file
```