### PR TITLE
Setup auto image building using campaigner

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# The user that clones the repository (root) is different from the user performing git commands
+git config --global --add safe.directory /go/src/github.com/DataDog/lemur
+
+# Determine the specific commit or release to build an image for
+IMAGE_TAG=$(echo $GBILITE_IMAGE_TO_BUILD | cut -d ':' -f 2)
+if [[ $GBILITE_IMAGE_TO_BUILD == "lemur:latest" ]]; then
+  LATEST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+  CHECKOUT_REF=$LATEST_RELEASE_TAG
+elif [[ -z "$CHECKOUT_REF" ]]; then
+  CHECKOUT_REF=$IMAGE_TAG
+fi
+
+# Build and sign the image
+cd publish/
+METADATA_FILE=$(mktemp)
+docker buildx build \
+  --label target=$GBILITE_ENV \
+  --build-arg CI_COMMIT_SHA=$CHECKOUT_REF \
+  --tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD \
+  --metadata-file ${METADATA_FILE} \
+  --push \
+  .
+ddsign sign registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD --docker-metadata-file ${METADATA_FILE}
+
+# Output image metadata (required by campaigner)
+cd ../
+echo $IMAGE_TAG .campaigns/image_info.txt
+echo $(crane digest registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD) >> .campaigns/image_info.txt

--- a/.campaigns/get_images.sh
+++ b/.campaigns/get_images.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The user that clones the repository (root) is different from the user performing git commands
+git config --global --add safe.directory /go/src/github.com/DataDog/lemur
+
+# Campaigner should always re-build images for the latest release
+LATEST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+echo "lemur:${LATEST_RELEASE_TAG}"
+echo "lemur:latest"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - test
   - build-stage-image
   - build-prod-image
+  - gbilite
 
 test:
   image: $CURRENT_CI_IMAGE
@@ -37,9 +38,7 @@ build-stage-image:
   image: $CURRENT_CI_IMAGE
   stage: build-stage-image
   when: on_success
-  # the 3h timeout is required for images compiling large projects for ARM using qemu
-  # we can revert back to 1h when we use native builders for ARM
-  timeout: 3h
+  timeout: 2h
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
@@ -47,16 +46,7 @@ build-stage-image:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   script:
-    - cd publish
-    - METADATA_FILE=$(mktemp)
-    - docker buildx build
-      --label target=staging
-      --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA}
-      --tag registry.ddbuild.io/lemur:v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
-      --metadata-file ${METADATA_FILE}
-      --push
-      .
-    - ddsign sign registry.ddbuild.io/lemur:v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA --docker-metadata-file ${METADATA_FILE}
+    - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" /bin/bash .campaigns/build_and_push_image.sh
   except:
     - tags
 
@@ -65,9 +55,7 @@ build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image
   when: on_success
-  # the 3h timeout is required for images compiling large projects for ARM using qemu
-  # we can revert back to 1h when we use native builders for ARM
-  timeout: 3h
+  timeout: 2h
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
@@ -75,15 +63,34 @@ build-prod-image:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   script:
-    - cd publish
-    - METADATA_FILE=$(mktemp)
-    - docker buildx build
-      --label target=staging
-      --build-arg CI_COMMIT_SHA=${CI_COMMIT_SHA}
-      --tag registry.ddbuild.io/lemur:$CI_COMMIT_TAG
-      --metadata-file ${METADATA_FILE}
-      --push
-      .
-    - ddsign sign registry.ddbuild.io/lemur:$CI_COMMIT_TAG --docker-metadata-file ${METADATA_FILE}
+    - GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$CI_COMMIT_TAG" /bin/bash .campaigns/build_and_push_image.sh
   only:
     - tags
+
+gbilite-get-images:
+  image: $CURRENT_CI_IMAGE
+  stage: gbilite
+  tags: ["arch:amd64"]
+  rules:
+    - if: $GBILITE_GITLAB_ACTION == "gbilite-get-images"
+  script:
+    - /bin/bash .campaigns/get_images.sh > .campaigns/allimages.txt
+  artifacts:
+    paths:
+      - .campaigns/allimages.txt
+
+gbilite-build-image:
+  image: $CURRENT_CI_IMAGE
+  stage: gbilite
+  timeout: 2h
+  tags: ["arch:amd64"]
+  rules:
+    - if: $GBILITE_GITLAB_ACTION == "gbilite-build-image"
+  script:
+    - /bin/bash .campaigns/build_and_push_image.sh
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  artifacts:
+    paths:
+      - .campaigns/image_info.txt


### PR DESCRIPTION
This PR sets up the necessary GitLab jobs that can be invoked automatically by campaigner to periodically rebuild and publish the container images for Lemur.