### PR TITLE
Bump ddtrace dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ CloudFlare
 cryptography >= 41.0.6 # Required to avoid vulnerability in previous version (VULN-5135)
 deprecated
 dnspython3
-ddtrace == 0.53.0 # Required for cert orchestration adapter.
+ddtrace == 1.16.1 # Required for cert orchestration adapter.
 dyn
 Flask-Bcrypt
 Flask-Mail

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ cryptography==41.0.7
     #   paramiko
     #   pyjwt
     #   pyopenssl
-ddtrace==0.53.0
+ddtrace==1.16.1
     # via
     #   -r requirements.in
     #   cert-orchestration-adapter


### PR DESCRIPTION
The build is currently failing because `ddtrace` dependency is out of date:

```
Collecting ddtrace==0.53.0 (from lemur==1.2.dev0)
  Downloading ddtrace-0.53.0.tar.gz (1.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 89.4 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [83 lines of output]
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/internal/_rand.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/profiling/_build.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/profiling/collector/_task.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/profiling/collector/_threading.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/profiling/collector/_traceback.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/profiling/exporter/pprof.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/internal/_encoding.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      warning: ddtrace/internal/_encoding.pyx:104:8: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      warning: ddtrace/internal/_encoding.pyx:217:12: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      warning: ddtrace/internal/_encoding.pyx:12:14: Function signature does not match previous declaration
      warning: ddtrace/internal/_encoding.pyx:218:44: Assigning to 'char *' from 'const char *' discards const qualifier
      /tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-tm725gmi/ddtrace_ecd715d0dd7349f59872dfdf7cdc93d8/ddtrace/profiling/collector/stack.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      warning: ddtrace/profiling/collector/stack.pyx:42:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      warning: ddtrace/profiling/collector/stack.pyx:167:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      warning: ddtrace/profiling/collector/stack.pyx:195:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      warning: ddtrace/profiling/collector/stack.pyx:219:8: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      warning: ddtrace/profiling/collector/stack.pyx:234:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
      [1/8] Cythonizing ddtrace/internal/_rand.pyx
      [2/8] Cythonizing ddtrace/profiling/_build.pyx
      [3/8] Cythonizing ddtrace/profiling/collector/_task.pyx
      [4/8] Cythonizing ddtrace/profiling/collector/_threading.pyx
      [5/8] Cythonizing ddtrace/profiling/collector/_traceback.pyx
      [6/8] Cythonizing ddtrace/profiling/exporter/pprof.pyx
      [7/8] Cythonizing ddtrace/internal/_encoding.pyx
      [8/8] Cythonizing ddtrace/profiling/collector/stack.pyx
      Traceback (most recent call last):
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools_scm/version.py", line 11, in <module>
          from packaging.version import Version
      ModuleNotFoundError: No module named 'packaging'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/home/dog/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/dog/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/dog/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 366, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 150, in <module>
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 146, in setup
          _setup_distribution = dist = klass(attrs)
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 307, in __init__
          _Distribution.__init__(self, dist_attrs)
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 284, in __init__
          self.finalize_options()
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 658, in finalize_options
          for ep in sorted(loaded, key=by_order):
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 657, in <lambda>
          loaded = map(lambda e: e.load(), filtered)
        File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
          module = import_module(match.group('module'))
        File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
          return _bootstrap._gcd_import(name[level:], package, level)
        File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
        File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
        File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
        File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line [688](https://gitlab.ddbuild.io/DataDog/lemur/-/jobs/528183740#L688), in _load_unlocked
        File "<frozen importlib._bootstrap_external>", line 883, in exec_module
        File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools_scm/__init__.py", line 15, in <module>
          from .version import format_version, meta
        File "/tmp/pip-build-env-pwjgncxi/overlay/lib/python3.10/site-packages/setuptools_scm/version.py", line 15, in <module>
          Version = pkg_resources.packaging.version.Version
      AttributeError: module 'pkg_resources' has no attribute 'packaging'
      [end of output]
```