### PR TITLE
Filter out test stage from GBI lite build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ test:
   stage: test
   timeout: 30m
   rules:
-    - if: $GBILITE_GITLAB_ACTION != "gbilite-get-images"
+    - if: $GBILITE_GITLAB_ACTION != "gbilite-get-images" && $GBILITE_GITLAB_ACTION != "gbilite-build-image"
   tags: ["arch:amd64"]
   variables:
     POSTGRES_DB: lemur


### PR DESCRIPTION
These test don't provide any additional validation or checking for top of the GBI lite build step so they don't need to be run in such cases.