### PR TITLE
updating value for LEMUR_ENCRYPTION_KEYS in local lemur config

### DIFF
--- a/docker/src/lemur.conf.py
+++ b/docker/src/lemur.conf.py
@@ -32,7 +32,7 @@ LEMUR_TOKEN_SECRET = repr(os.environ.get('LEMUR_TOKEN_SECRET',
                                          base64.b64encode(get_random_secret(32).encode('utf8'))))
 # This must match the key for whichever DB the container is using - this could be a dump of dev or test, or a unique key
 LEMUR_ENCRYPTION_KEYS = repr(os.environ.get('LEMUR_ENCRYPTION_KEYS',
-                                            base64.b64encode(b'SBRHNTIW@%#$)_#+ulahitit47774808').decode('utf8')))
+                                            base64.b64encode(get_random_secret(32).encode('utf8')).decode('utf8')))
 
 # this is the secret used to generate oauth state tokens
 OAUTH_STATE_TOKEN_SECRET = repr(os.environ.get('OAUTH_STATE_TOKEN_SECRET', base64.b64encode(get_random_secret(32).encode('utf8'))))


### PR DESCRIPTION
### What does this PR do?
Removes the hardcoded key in the lemur.conf file used for local testing.

### Background
The key was previously hardcoded to work around an issue where LEMUR_ENCRYPTION_KEYS would rotate, causing DB queries to fail due to a key mismatch. Although this lemur.conf file is only for local testing, it's best to eliminate the practice of hardcoding values. This PR will set the value to match what is upstream.