### PR TITLE
Upgrade the GBI to Ubuntu 22.04 to use new Python version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.2.2 - `2024-11-01`
+~~~~~~~~~~~~~~~~~~~~
+
+Updated the GBI to Ubuntu 22.04 to deprecate Python 3.8 and solve a crash loop when deploying.
+
 1.2.1 - `2024-10-18`
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,5 @@
 # Lemur Builder
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:master as builder
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:release as builder
 
 ARG CI_COMMIT_SHA
 
@@ -39,7 +39,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:master
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
 
 USER root
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,5 @@
 # Lemur Builder
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2004 as builder
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204 as builder
 
 ARG CI_COMMIT_SHA
 
@@ -39,7 +39,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2004
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204
 
 USER root
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,5 @@
 # Lemur Builder
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204 as builder
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:master as builder
 
 ARG CI_COMMIT_SHA
 
@@ -39,7 +39,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:master
 
 USER root
 


### PR DESCRIPTION
Upgrade the GBI to Ubuntu 22.04 to use new Python version

Previous GBI Ubuntu 20.04 came with Python 3.8 causing a crash loop due to Python:

```
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 655, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 929, in _generate_schema_inner
    return self.match_type(obj)
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 1029, in match_type
    return self._match_generic_type(obj, origin)
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 1062, in _match_generic_type
    return self._list_schema(self._get_first_arg_or_any(obj))
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 892, in _get_first_arg_or_any
    args = self._get_args_resolving_forward_refs(obj)
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 886, in _get_args_resolving_forward_refs
    args = tuple([self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args])
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 886, in <listcomp>
    args = tuple([self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args])
  File "/opt/venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 866, in _resolve_forward_ref
    raise PydanticUndefinedAnnotation.from_name_error(e) from e
pydantic.errors.PydanticUndefinedAnnotation: name 'TraceItem' is not defined

For further information visit https://errors.pydantic.dev/2.9/u/undefined-annotation
```