### PR TITLE
Add support for FIPS mode

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -6,10 +6,17 @@ git config --global --add safe.directory /go/src/github.com/DataDog/lemur
 
 # Determine the specific commit or release to build an image for
 IMAGE_TAG=$(echo $GBILITE_IMAGE_TO_BUILD | cut -d ':' -f 2)
+BASE_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
+FIPS_ENABLED=false
 if [[ $GBILITE_IMAGE_TO_BUILD == "lemur:latest" ]]; then
   LATEST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
   CHECKOUT_REF=$LATEST_RELEASE_TAG
-elif [[ -z "$CHECKOUT_REF" ]]; then
+elif [[ $GBILITE_IMAGE_TO_BUILD == *"-fips" ]]; then
+  BASE_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
+  FIPS_ENABLED=true
+fi
+
+if [[ -z "$CHECKOUT_REF" ]]; then
   CHECKOUT_REF=$IMAGE_TAG
 fi
 
@@ -19,6 +26,8 @@ METADATA_FILE=$(mktemp)
 docker buildx build \
   --label target=$GBILITE_ENV \
   --build-arg CI_COMMIT_SHA=$CHECKOUT_REF \
+  --build-arg BASE_IMAGE=$BASE_IMAGE \
+  --build-arg FIPS_ENABLED=$FIPS_ENABLED \
   --tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD \
   --metadata-file ${METADATA_FILE} \
   --push \

--- a/.campaigns/get_images.sh
+++ b/.campaigns/get_images.sh
@@ -7,4 +7,5 @@ git config --global --add safe.directory /go/src/github.com/DataDog/lemur
 # Campaigner should always re-build images for the latest release
 LATEST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 echo "lemur:${LATEST_RELEASE_TAG}"
+echo "lemur:${LATEST_RELEASE_TAG}-fips"
 echo "lemur:latest"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,9 @@ variables:
 stages:
   - test
   - build-stage-image
+  - build-stage-image-fips
   - build-prod-image
+  - build-prod-image-fips
   - gbilite
 
 test:
@@ -52,6 +54,22 @@ build-stage-image:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" /bin/bash .campaigns/build_and_push_image.sh
 
+build-stage-image-fips:
+  image: $CURRENT_CI_IMAGE
+  stage: build-stage-image-fips
+  when: on_success
+  rules:
+    - if: ($CI_COMMIT_TAG == null && $GBILITE_GITLAB_ACTION == null)
+  timeout: 2h
+  tags: ["arch:amd64"]
+  variables:
+    CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  script:
+    - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
+
 # build a prod image when we create a new tag
 build-prod-image:
   image: $CURRENT_CI_IMAGE
@@ -68,6 +86,22 @@ build-prod-image:
       aud: image-integrity
   script:
     - GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$CI_COMMIT_TAG" /bin/bash .campaigns/build_and_push_image.sh
+
+build-prod-image-fips:
+  image: $CURRENT_CI_IMAGE
+  stage: build-prod-image-fips
+  when: on_success
+  timeout: 2h
+  rules:
+    - if: $CI_COMMIT_TAG
+  tags: ["arch:amd64"]
+  variables:
+    CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  script:
+    - GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$CI_COMMIT_TAG-fips" /bin/bash .campaigns/build_and_push_image.sh
 
 gbilite-get-images:
   image: $CURRENT_CI_IMAGE

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -26,6 +26,7 @@ from lemur.constants import ACME_ADDITIONAL_ATTEMPTS
 from lemur.dns_providers import cli as cli_dns_providers
 from lemur.extensions import metrics
 from lemur.factory import create_app
+from lemur import fips
 from lemur.notifications import cli as cli_notification
 from lemur.notifications.messaging import (
     send_pending_failure_notification,
@@ -35,6 +36,8 @@ from lemur.notifications.messaging import (
 from lemur.pending_certificates import service as pending_certificate_service
 from lemur.plugins.base import plugins
 from lemur.sources.cli import clean, sync, validate_sources
+
+fips.instance.maybe_enable_fips()
 
 if current_app:
     flask_app = current_app

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -37,7 +37,7 @@ from lemur.pending_certificates import service as pending_certificate_service
 from lemur.plugins.base import plugins
 from lemur.sources.cli import clean, sync, validate_sources
 
-fips.instance.maybe_enable_fips()
+fips.instance.must_enable_fips_if_needed()
 
 if current_app:
     flask_app = current_app

--- a/lemur/fips.py
+++ b/lemur/fips.py
@@ -1,0 +1,227 @@
+import ctypes
+import ctypes.util
+import logging
+import os
+import sys
+from types import SimpleNamespace
+
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+class OpensslFipsStatus:
+    # Represents OpenSSL version `3.0.0`, according to the format used by `OpenSSL_version_num`.
+    # Because OpenSSL 3.x reworks FIPS mode significantly, we target only OpenSSL 3.x,
+    # and our minimum permitted version is OpenSSL 3.0.0.
+    _OPENSSL_MINIMUM_VERSION = 0x3_00_00_00_0
+
+    def __init__(self) -> None:
+        self._init_ffi()
+
+    def _init_ffi(self) -> None:
+        ffi_init = {
+            "darwin": self._init_ffi_darwin,
+            "linux": self._init_ffi_linux,
+        }
+        ffi_init[sys.platform]()
+
+    def _init_ffi_darwin(self) -> None:
+        """Initialize the FFI structure for darwin.
+
+        Since we cannot currently enable FIPS mode on macOS,
+        we stub out the structure we need so that the rest of the methods can work.
+        """
+        self._ffi = SimpleNamespace(
+            types=SimpleNamespace(
+                p_OSSL_LIB_CTX=None,
+                p_OSSL_PROVIDER=None,
+            ),
+            functions=SimpleNamespace(
+                EVP_default_properties_enable_fips=None,
+                EVP_default_properties_is_fips_enabled=None,
+                OSSL_PROVIDER_load=None,
+                OpenSSL_version=None,
+                OpenSSL_version_num=None,
+            ),
+            libraries=SimpleNamespace(
+                libcrypto=None,
+            ),
+            constants=SimpleNamespace(
+                OPENSSL_VERSION=None,
+            ),
+        )
+
+    def _init_ffi_linux(self) -> None:
+        self._ffi = SimpleNamespace()
+
+        self._ffi.types = SimpleNamespace()
+        # OSSL_LIB_CTX *
+        # https://docs.openssl.org/3.4/man3/OSSL_LIB_CTX/#synopsis
+        self._ffi.types.p_OSSL_LIB_CTX = ctypes.c_void_p
+        # OSSL_PROVIDER *
+        # https://docs.openssl.org/3.4/man3/OSSL_PROVIDER/#synopsis
+        self._ffi.types.p_OSSL_PROVIDER = ctypes.c_void_p
+
+        self._ffi.constants = SimpleNamespace()
+        # https://github.com/openssl/openssl/blob/c262cc0c0444f617387adac3ed4cad9f05f9c526/include/openssl/crypto.h.in#L164
+        self._ffi.constants.OPENSSL_VERSION = 0
+
+        self._ffi.libraries = SimpleNamespace()
+
+        try:
+            self._ffi.libraries.libcrypto = ctypes.CDLL(
+                ctypes.util.find_library("crypto")
+            )
+        except OSError:
+            self._ffi.libraries.libcrypto = None
+
+        self._ffi.functions = SimpleNamespace()
+
+        if self._ffi.libraries.libcrypto is not None:
+            try:
+                # https://docs.openssl.org/3.4/man3/OpenSSL_version/#functions
+                self._ffi.functions.OpenSSL_version_num = (
+                    self._ffi.libraries.libcrypto.OpenSSL_version_num
+                )
+                self._ffi.functions.OpenSSL_version_num.argtypes = ()
+                self._ffi.functions.OpenSSL_version_num.restype = ctypes.c_ulong
+            except AttributeError:
+                self._ffi.functions.OpenSSL_version_num = None
+
+        if self._ffi.libraries.libcrypto is not None:
+            try:
+                # https://docs.openssl.org/3.4/man3/OpenSSL_version/#functions
+                self._ffi.functions.OpenSSL_version = (
+                    self._ffi.libraries.libcrypto.OpenSSL_version
+                )
+                self._ffi.functions.OpenSSL_version.argtypes = (ctypes.c_int,)
+                self._ffi.functions.OpenSSL_version.restype = ctypes.c_char_p
+            except AttributeError:
+                self._ffi.functions.OpenSSL_version = None
+
+        if self._ffi.libraries.libcrypto is not None:
+            try:
+                # https://docs.openssl.org/3.4/man3/OSSL_PROVIDER/#functions
+                self._ffi.functions.OSSL_PROVIDER_load = (
+                    self._ffi.libraries.libcrypto.OSSL_PROVIDER_load
+                )
+                self._ffi.functions.OSSL_PROVIDER_load.argtypes = (
+                    self._ffi.types.p_OSSL_LIB_CTX,
+                    ctypes.c_char_p,
+                )
+                self._ffi.functions.OSSL_PROVIDER_load.restype = (
+                    self._ffi.types.p_OSSL_PROVIDER
+                )
+            except AttributeError:
+                self._ffi.functions.OSSL_PROVIDER_load = None
+
+        if self._ffi.libraries.libcrypto is not None:
+            try:
+                # https://docs.openssl.org/3.4/man3/EVP_set_default_properties/
+                self._ffi.functions.EVP_default_properties_is_fips_enabled = (
+                    self._ffi.libraries.libcrypto.EVP_default_properties_is_fips_enabled
+                )
+                self._ffi.functions.EVP_default_properties_is_fips_enabled.argtypes = (
+                    self._ffi.types.p_OSSL_LIB_CTX,
+                )
+                self._ffi.functions.EVP_default_properties_is_fips_enabled.restype = (
+                    ctypes.c_int
+                )
+            except AttributeError:
+                self._ffi.functions.EVP_default_properties_is_fips_enabled = None
+
+        if self._ffi.libraries.libcrypto is not None:
+            try:
+                self._ffi.functions.EVP_default_properties_enable_fips = (
+                    self._ffi.libraries.libcrypto.EVP_default_properties_enable_fips
+                )
+                self._ffi.functions.EVP_default_properties_enable_fips.argtypes = (
+                    self._ffi.types.p_OSSL_LIB_CTX,
+                    ctypes.c_int,
+                )
+                self._ffi.functions.EVP_default_properties_enable_fips.restype = (
+                    ctypes.c_int
+                )
+            except AttributeError:
+                self._ffi.functions.EVP_default_properties_enable_fips = None
+
+    def debug_openssl_version(self) -> dict[str, str]:
+        result = {}
+        if (
+            self._ffi.libraries.libcrypto is not None
+            and self._ffi.functions.OpenSSL_version is not None
+        ):
+            # Only `OPENSSL_VERSION` is guaranteed across both OpenSSL major versions 1 and 3.
+            # This will ensure that, even on OpenSSL major version 1, we get a meaningful result.
+            openssl_version = self._ffi.functions.OpenSSL_version(
+                self._ffi.constants.OPENSSL_VERSION
+            )
+            result["openssl_version"] = openssl_version
+        return result
+
+    def check_openssl_version(self) -> bool:
+        """Checks that the current OpenSSL version (as dynamically loaded by Python) is new enough for FIPS purposes."""
+        if not (
+            self._ffi.libraries.libcrypto is not None
+            and self._ffi.functions.OpenSSL_version_num is not None
+        ):
+            return False
+        return (
+            self._ffi.functions.OpenSSL_version_num() >= self._OPENSSL_MINIMUM_VERSION
+        )
+
+    def debug_fips_status(self) -> dict[str, bool]:
+        result = {}
+        if (
+            self._ffi.libraries.libcrypto is not None
+            and self._ffi.functions.EVP_default_properties_is_fips_enabled is not None
+        ):
+            default_context_is_fips_enabled = (
+                self._ffi.functions.EVP_default_properties_is_fips_enabled(None) == 1
+            )
+            result["default_context_is_fips_enabled"] = default_context_is_fips_enabled
+        return result
+
+    def check_fips_enabled(self) -> bool:
+        """Checks that the current OpenSSL (as dynamically loaded by Python) is FIPS mode enabled."""
+        if not (
+            self.check_openssl_version()
+            and self._ffi.libraries.libcrypto is not None
+            and self._ffi.functions.EVP_default_properties_is_fips_enabled is not None
+        ):
+            return False
+        return self._ffi.functions.EVP_default_properties_is_fips_enabled(None) == 1
+
+    def _load_fips_provider(self) -> bool:
+        if not (
+            self._ffi.libraries.libcrypto is not None
+            and self._ffi.functions.OSSL_PROVIDER_load is not None
+        ):
+            return False
+        return self._ffi.functions.OSSL_PROVIDER_load(None, b"fips") is not None
+
+    def _default_properties_enable_fips(self) -> bool:
+        if not (
+            self._ffi.libraries.libcrypto is not None
+            and self._ffi.functions.EVP_default_properties_enable_fips is not None
+        ):
+            return False
+        return self._ffi.functions.EVP_default_properties_enable_fips(None, 1) == 1
+
+    def enable_fips(self) -> bool:
+        """Enables FIPS mode for the current OpenSSL (as dynamically loaded by Python)."""
+        return self._load_fips_provider() and self._default_properties_enable_fips()
+
+    def maybe_enable_fips(self) -> bool:
+        """Enables FIPS mode for the current OpenSSL if FIPS_ENABLED env var is set to true."""
+        if os.environ.get("FIPS_ENABLED", "false").lower().strip() == "true":
+            self.enable_fips()
+        if self.check_fips_enabled():
+            logging.info("FIPS mode enabled")
+            return True
+        return False
+
+
+instance = OpensslFipsStatus()

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -59,7 +59,7 @@ manager.add_option("-c", "--config", dest="config_path", required=False)
 
 migrate = Migrate(create_app)
 
-fips.instance.maybe_enable_fips()
+fips.instance.must_enable_fips_if_needed()
 
 REQUIRED_VARIABLES = [
     "LEMUR_SECURITY_TEAM_EMAIL",

--- a/lemur/manage.py
+++ b/lemur/manage.py
@@ -35,6 +35,8 @@ from lemur.common.utils import validate_conf
 
 from lemur import create_app
 
+from lemur import fips
+
 # Needed to be imported so that SQLAlchemy create_all can find our models
 from lemur.users.models import User  # noqa
 from lemur.roles.models import Role  # noqa
@@ -56,6 +58,8 @@ manager = Manager(create_app)
 manager.add_option("-c", "--config", dest="config_path", required=False)
 
 migrate = Migrate(create_app)
+
+fips.instance.maybe_enable_fips()
 
 REQUIRED_VARIABLES = [
     "LEMUR_SECURITY_TEAM_EMAIL",

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,5 @@
 # Lemur Builder
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:release as builder
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release as builder
 
 ARG CI_COMMIT_SHA
 
@@ -39,7 +39,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
 
 USER root
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -41,6 +41,8 @@ RUN npm config set registry http://registry.npmjs.org/ && \
 # Lemur Application
 FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
 
+LABEL is_fips=true
+
 USER root
 
 RUN apt-get update && apt-get -y install jq

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,5 +1,8 @@
+# Base Image Selection
+ARG BASE_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
+
 # Lemur Builder
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release as builder
+FROM $BASE_IMAGE as builder
 
 ARG CI_COMMIT_SHA
 
@@ -39,9 +42,11 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     rm -rf node_modules
 
 # Lemur Application
-FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
+FROM $BASE_IMAGE
 
-LABEL is_fips=true
+# FIPS mode
+ARG FIPS_ENABLED=false
+LABEL IS_FIPS=$FIPS_ENABLED
 
 USER root
 
@@ -52,5 +57,7 @@ COPY --from=builder /opt/venv /opt/venv
 
 RUN clean-apt install python3 python3-distutils haveged curl postgresql-client openssl &&\
     chown -R dog:dog /opt
+
+ENV FIPS_ENABLED=$FIPS_ENABLED
 
 USER dog

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -28,7 +28,7 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     npm install npm -g && \
     echo "Running with nodejs:" && node -v && \
     python3 -m venv /opt/venv && \
-    echo "Running with python:" && /opt/venv/bin/python3 -c 'import platform; print(platform.python_version())' && \
+    echo "Running with python:" && /opt/venv/bin/python3 -c 'import sys, platform; print("sys.platform == {}, platform.machine == {}, platform.python_version == {}".format(sys.platform, platform.machine(), platform.python_version()))' && \
     /opt/venv/bin/python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     # ddtrace is required to automatically instrument lemur to emit traces
     /opt/venv/bin/python3 -m pip install --no-cache-dir ddtrace && \
@@ -40,6 +40,10 @@ RUN npm config set registry http://registry.npmjs.org/ && \
     node_modules/.bin/gulp --cwd /opt/lemur package && \
     npm cache clean --force && \
     rm -rf node_modules
+
+# Install requirement overrides. Required for FIPS mode.
+RUN echo "Installing requirement overrides:" && /opt/venv/bin/python3 -c 'import sys, platform; print("sys.platform == {}, platform.machine == {}, platform.python_version == {}".format(sys.platform, platform.machine(), platform.python_version()))'
+RUN /opt/venv/bin/python3 -m pip install --no-cache-dir --no-deps --force-reinstall -r requirements-overrides.txt
 
 # Lemur Application
 FROM $BASE_IMAGE

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,4 +4,5 @@ flake8
 invoke
 nodeenv
 pre-commit
+cryptography==43.0.1 # Must keep `cryptography` pinned to the same version as `requirements-overrides.txt` for FIPS support.
 -r requirements-tests.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -202,7 +202,7 @@ configobj==5.0.9
     #   certbot
 coverage==7.6.4
     # via -r requirements-tests.txt
-cryptography==43.0.3
+cryptography==43.0.1
     # via
     #   -r requirements-tests.txt
     #   acme

--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -11,7 +11,7 @@ celery[redis]
 certbot
 certsrv
 CloudFlare
-cryptography
+cryptography==43.0.1 # Must keep `cryptography` pinned to the same version as `requirements-overrides.txt` for FIPS support.
 dnspython >= 2.6.0
 dnspython3
 dyn

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -217,7 +217,7 @@ configobj==5.0.9
     #   certbot
 coverage==7.6.4
     # via -r requirements-tests.txt
-cryptography==43.0.3
+cryptography==43.0.1
     # via
     #   -r requirements-docs.in
     #   -r requirements-tests.txt

--- a/requirements-overrides.txt
+++ b/requirements-overrides.txt
@@ -1,0 +1,8 @@
+# cryptography:
+# On Linux, cryptography statically links OpenSSL.
+# For FIPS compliance, we rebuild against the FIPS-compliant OpenSSL installation in the FIPS GBI.
+#
+# jammy version with OpenSSL 3
+https://binaries.ddbuild.io/repackaging/python-cryptography-fips/cryptography-43.0.1+dd.repackaging.45120575-cp37-abi3-linux_x86_64.whl ; sys_platform == "linux" and platform_machine == "x86_64" and python_full_version == "3.10.12"
+# jammy version with OpenSSL 3
+https://binaries.ddbuild.io/repackaging/python-cryptography-fips/cryptography-43.0.1+dd.repackaging.45120575-cp37-abi3-linux_aarch64.whl ; sys_platform == "linux" and platform_machine == "aarch64" and python_full_version == "3.10.12"

--- a/requirements-tests.in
+++ b/requirements-tests.in
@@ -4,6 +4,7 @@ bandit
 black
 celery[redis]>=5.3.5
 coverage
+cryptography==43.0.1 # Must keep `cryptography` pinned to the same version as `requirements-overrides.txt` for FIPS support.
 factory-boy
 Faker
 fakeredis

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -195,7 +195,7 @@ configobj==5.0.9
     #   certbot
 coverage==7.6.4
     # via -r requirements-tests.in
-cryptography==43.0.3
+cryptography==43.0.1
     # via
     #   -r requirements.txt
     #   acme

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ certbot
 certifi
 certsrv[ntlm]
 CloudFlare
-cryptography
+cryptography==43.0.1 # Must keep `cryptography` pinned to the same version as `requirements-overrides.txt` for FIPS support.
 dnspython == 2.6.1
 dnspython3
 dyn

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,7 +131,7 @@ configargparse==1.7
     # via certbot
 configobj==5.0.9
     # via certbot
-cryptography==43.0.3
+cryptography==43.0.1
     # via
     #   -r requirements.in
     #   acme


### PR DESCRIPTION
- Enable FIPS mode within the application server and celery workers before initialization if `FIPS_ENABLED=true`.
- Create separate image build and release pipelines for FIPS and non-FIPS images. Both images will be periodically re-built with campaigner and GBILite.
- The FIPS images are tagged with the `IS_FIPS=true` label for tracking purposes.