### PR TITLE
Fix prod FIPS image build

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -20,6 +20,11 @@ if [[ -z "$CHECKOUT_REF" ]]; then
   CHECKOUT_REF=$IMAGE_TAG
 fi
 
+if [[ $FIPS_ENABLED == "true" ]]; then
+  # Release tags to build FIPS images for do not contain the -fips postfix.
+  CHECKOUT_REF=${CHECKOUT_REF%-fips}
+fi
+
 # Build and sign the image
 cd publish/
 METADATA_FILE=$(mktemp)


### PR DESCRIPTION
Both FIPS and non-FIPS images will be built against a single release tag to keep the release process simple. As such, if we're building a FIPS image to be tagged `1.0.0-dd.32-fips`, we need to checkout the source code present at the release tag for `1.0.0-dd.32`.