### PR TITLE
Remove future package dependency to fix CVE-2025-50817

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,6 @@ flask-Script==2.0.5
 Flask-SQLAlchemy
 Flask<3  # until https://github.com/pytest-dev/pytest-flask/pull/168 is released
 flask_replicated
-future
 google-cloud-compute
 google-cloud-private-ca
 grpcio >= 1.62.0 # (VULN-7774)

--- a/requirements.txt
+++ b/requirements.txt
@@ -200,7 +200,6 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
-future==1.0.0
     # via -r requirements.in
 google-api-core[grpc]==2.23.0
     # via


### PR DESCRIPTION
- Remove future==1.0.0 from requirements.in and requirements.txt
- This eliminates the CVE-2025-50817 vulnerability
- The future package was not actually used in the codebase (only __future__ imports)