### PR TITLE
Bump COA wheel to 0.1.33

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -505,7 +505,7 @@ def clean_source(source):
 
 
 @celery_app.task()
-def clear_sync_chain_flag():
+def complete_sync_chain():
     red.delete("sync_chain_active")
     # Mark sync_all_sources as successful now that all sources have synced
     function = f"{__name__}.sync_all_sources"
@@ -543,13 +543,13 @@ def sync_all_sources():
     sources = validate_sources("all")
     # Source syncs are heavy, chain them sequentially so they don't flood the queue
     from celery import chain
-    red.set("sync_chain_active", "1", ex=7200)  # cleared by clear_sync_chain_flag at end of chain, 2h expiry is a safety net
+    red.set("sync_chain_active", "1", ex=7200)  # cleared by complete_sync_chain at end of chain, 2h expiry is a safety net
     tasks = []
     for source in sources:
         log_data["source"] = source.label
         current_app.logger.debug(log_data)
         tasks.append(sync_source.si(source.label))
-    tasks.append(clear_sync_chain_flag.si())
+    tasks.append(complete_sync_chain.si())
     if tasks:
         chain(*tasks).delay()
 

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -505,6 +505,15 @@ def clean_source(source):
 
 
 @celery_app.task()
+def clear_sync_chain_flag():
+    red.delete("sync_chain_active")
+    # Mark sync_all_sources as successful now that all sources have synced
+    function = f"{__name__}.sync_all_sources"
+    red.set(f"{function}.last_success", int(time.time()))
+    metrics.send(f"{function}.success", "counter", 1)
+
+
+@celery_app.task()
 def sync_all_sources():
     """
     This function will sync certificates from all sources. This function triggers one celery task per source.
@@ -525,22 +534,29 @@ def sync_all_sources():
         current_app.logger.debug(log_data)
         return
 
+    # Skip if a previous sync chain is still running
+    if red.get("sync_chain_active"):
+        log_data["message"] = "Skipping: previous sync chain is still running"
+        current_app.logger.warning(log_data)
+        return log_data
+
     sources = validate_sources("all")
     # Source syncs are heavy, chain them sequentially so they don't flood the queue
     from celery import chain
+    red.set("sync_chain_active", "1", ex=7200)  # cleared by clear_sync_chain_flag at end of chain, 2h expiry is a safety net
     tasks = []
     for source in sources:
         log_data["source"] = source.label
         current_app.logger.debug(log_data)
         tasks.append(sync_source.si(source.label))
+    tasks.append(clear_sync_chain_flag.si())
     if tasks:
         chain(*tasks).delay()
 
-    metrics.send(f"{function}.success", "counter", 1)
     return log_data
 
 
-@celery_app.task(soft_time_limit=7200)
+@celery_app.task(soft_time_limit=900)  # fail if a source task gets stuck
 def sync_source(source):
     """
     This celery task will sync the specified source.
@@ -571,9 +587,6 @@ def sync_source(source):
         sync(
             [source], current_app.config.get("CELERY_ENDPOINTS_EXPIRE_TIME_IN_HOURS", 2)
         )
-        metrics.send(
-            f"{function}.success", "counter", 1, metric_tags={"source": source}
-        )
     except SoftTimeLimitExceeded:
         log_data["message"] = "Error syncing source: Time limit exceeded."
         current_app.logger.error(log_data)
@@ -582,6 +595,12 @@ def sync_source(source):
             "sync_source_timeout", "counter", 1, metric_tags={"source": source}
         )
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
+        return
+    except Exception as e:
+        log_data["message"] = f"Error syncing source: {e}"
+        current_app.logger.error(log_data)
+        capture_exception()
+        metrics.send(f"{function}.failure", "counter", 1, metric_tags={"source": source})
         return
 
     log_data["message"] = "Done syncing source"

--- a/requirements-dd-source.in
+++ b/requirements-dd-source.in
@@ -3,6 +3,6 @@
 #
 # To bump a version: update the URL here and rebuild the Docker image.
 
-https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.32-py3-none-any.whl
+https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.33-py3-none-any.whl
 # Must match version enforced in the above COA wheel's requires (dd-source BUILD.bazel)
 https://binaries.ddbuild.io/dd-source/python/dd_internal_authentication-1.9.0-py2.py3-none-any.whl


### PR DESCRIPTION
Fixes empty plugin dropdowns in Lemur UI. The standalone base classes in COA 0.1.32 had two bugs:
1. check_validation returned a function instead of a pattern string, breaking JSON serialization of plugin options
2. Missing validate_option_value method caused 500 errors when editing destinations

dd-source PR: https://github.com/DataDog/dd-source/pull/402273