### PR TITLE
Cherry-pick: Access control vulnerability fixes (Netflix PR #4538)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ RUN pip install coveralls bandit
 WORKDIR /app
 COPY . /app/
 RUN pip install -e .
-RUN pip install --no-cache-dir "file://`pwd`#egg=lemur[dev]"
-RUN pip install --no-cache-dir "file://`pwd`#egg=lemur[tests]"
+RUN pip install --no-cache-dir -e ".[dev]"
+RUN pip install --no-cache-dir -e ".[tests]"
 

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -229,6 +229,20 @@ Basic Configuration
        Specifies the AWS partition that Lemur should use. Valid values are 'aws', 'aws-us-gov', and 'aws-cn'. Defaults to 'aws'.
        If Lemur is deployed in and managing endpoints AWS GovCloud, for example, you must set this to `aws-us-gov`.
 
+
+.. data:: LEMUR_STRICT_ROLE_ENFORCEMENT
+    :noindex:
+
+        When set to True, this property enforces the default Lemur role functionality. The default Lemur roles are
+        ``admin``, ``operator``, and ``read-only``. Users will be required to have a default role assigned
+        upon creation. The ``operator`` and ``read-only`` roles are strictly enforced. Users assigned the ``read-only``
+        role will not be able to create/update resources.
+
+    ::
+
+        LEMUR_STRICT_ROLE_ENFORCEMENT = False
+
+
 .. data:: SENTRY_DSN
     :noindex:
 

--- a/lemur/auth/permissions.py
+++ b/lemur/auth/permissions.py
@@ -60,6 +60,15 @@ class RoleMemberPermission(Permission):
         super(RoleMemberPermission, self).__init__(*needs)
 
 
+class AuthorityCreatorPermission(Permission):
+    def __init__(self):
+        requires_admin = current_app.config.get("ADMIN_ONLY_AUTHORITY_CREATION", False)
+        if requires_admin:
+            super(AuthorityCreatorPermission, self).__init__(RoleNeed("admin"))
+        else:
+            super(AuthorityCreatorPermission, self).__init__()
+
+
 AuthorityCreator = namedtuple("authority", ["method", "value"])
 AuthorityCreatorNeed = partial(AuthorityCreator, "authorityUse")
 
@@ -74,3 +83,13 @@ class AuthorityPermission(Permission):
             needs.append(AuthorityOwnerNeed(str(r)))
 
         super(AuthorityPermission, self).__init__(*needs)
+
+
+class StrictRolePermission(Permission):
+    def __init__(self):
+        strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", False)
+        if strict_role_enforcement:
+            needs = [RoleNeed("admin"), RoleNeed("operator")]
+            super(StrictRolePermission, self).__init__(*needs)
+        else:
+            super(StrictRolePermission, self).__init__()

--- a/lemur/authorities/views.py
+++ b/lemur/authorities/views.py
@@ -13,7 +13,7 @@ from lemur.common import validators
 from lemur.common.utils import paginated_parser
 from lemur.common.schema import validate_schema
 from lemur.auth.service import AuthenticatedResource
-from lemur.auth.permissions import AuthorityPermission
+from lemur.auth.permissions import AuthorityCreatorPermission, AuthorityPermission, StrictRolePermission
 
 from lemur.certificates import service as certificate_service
 
@@ -228,6 +228,10 @@ class AuthoritiesList(AuthenticatedResource):
            :statuscode 403: unauthenticated
            :statuscode 200: no error
         """
+        permission = AuthorityCreatorPermission()
+        if not permission.can() or not StrictRolePermission().can():
+            return dict(message="You are not allowed to create a new authority."), 403
+
         if not validators.is_valid_owner(data["owner"]):
             return (
                 dict(
@@ -412,16 +416,16 @@ class Authorities(AuthenticatedResource):
         roles = [x.name for x in authority.roles]
         permission = AuthorityPermission(authority_id, roles)
 
-        if permission.can():
-            return service.update(
-                authority_id,
-                owner=data["owner"],
-                description=data["description"],
-                active=data["active"],
-                roles=data["roles"],
-            )
+        if not permission.can() or not StrictRolePermission().can():
+            return dict(message="You are not authorized to update this authority."), 403
 
-        return dict(message="You are not authorized to update this authority."), 403
+        return service.update(
+            authority_id,
+            owner=data["owner"],
+            description=data["description"],
+            active=data["active"],
+            roles=data["roles"],
+        )
 
 
 class CertificateAuthority(AuthenticatedResource):

--- a/lemur/certificates/views.py
+++ b/lemur/certificates/views.py
@@ -20,7 +20,7 @@ from lemur.common.schema import validate_schema
 from lemur.common.utils import paginated_parser
 
 from lemur.auth.service import AuthenticatedResource
-from lemur.auth.permissions import AuthorityPermission, CertificatePermission
+from lemur.auth.permissions import AuthorityPermission, CertificatePermission, StrictRolePermission
 
 from lemur.certificates import service
 from lemur.certificates.models import Certificate
@@ -504,6 +504,9 @@ class CertificatesList(AuthenticatedResource):
            :statuscode 403: unauthenticated
 
         """
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to create a new certificate."), 403
+
         if not validators.is_valid_owner(data["owner"]):
             return (
                 dict(
@@ -648,6 +651,9 @@ class CertificatesUpload(AuthenticatedResource):
            :statuscode 200: no error
 
         """
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to upload a certificate."), 403
+
         data["creator"] = g.user
         if data.get("destinations"):
             if data.get("private_key"):

--- a/lemur/destinations/views.py
+++ b/lemur/destinations/views.py
@@ -99,8 +99,8 @@ class DestinationsList(AuthenticatedResource):
         args = parser.parse_args()
         return service.render(args)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(destination_input_schema, destination_output_schema)
+    @admin_permission.require(http_exception=403)
     def post(self, data=None):
         """
         .. http:post:: /destinations
@@ -251,8 +251,8 @@ class Destinations(AuthenticatedResource):
         """
         return service.get(destination_id)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(destination_input_schema, destination_output_schema)
+    @admin_permission.require(http_exception=403)
     def put(self, destination_id, data=None):
         """
         .. http:put:: /destinations/1

--- a/lemur/domains/views.py
+++ b/lemur/domains/views.py
@@ -13,7 +13,7 @@ from flask_restful import reqparse, Api
 
 from lemur.domains import service
 from lemur.auth.service import AuthenticatedResource
-from lemur.auth.permissions import SensitiveDomainPermission
+from lemur.auth.permissions import SensitiveDomainPermission, StrictRolePermission
 
 from lemur.common.schema import validate_schema
 from lemur.common.utils import paginated_parser
@@ -129,6 +129,8 @@ class DomainsList(AuthenticatedResource):
            :statuscode 200: no error
            :statuscode 403: unauthenticated
         """
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to create a domain"), 403
         return service.create(data["name"], data["sensitive"])
 
 
@@ -210,10 +212,9 @@ class Domains(AuthenticatedResource):
            :statuscode 200: no error
            :statuscode 403: unauthenticated
         """
-        if SensitiveDomainPermission().can():
-            return service.update(domain_id, data["name"], data["sensitive"])
-
-        return dict(message="You are not authorized to modify this domain"), 403
+        if not StrictRolePermission().can() or not SensitiveDomainPermission().can():
+            return dict(message="You are not authorized to modify this domain."), 403
+        return service.update(domain_id, data["name"], data["sensitive"])
 
 
 class CertificateDomains(AuthenticatedResource):

--- a/lemur/notifications/views.py
+++ b/lemur/notifications/views.py
@@ -18,6 +18,7 @@ from lemur.notifications.schemas import (
 
 from lemur.auth.service import AuthenticatedResource
 from lemur.common.utils import paginated_parser
+from lemur.auth.permissions import StrictRolePermission
 
 from lemur.common.schema import validate_schema
 
@@ -224,6 +225,8 @@ class NotificationsList(AuthenticatedResource):
            :reqheader Authorization: OAuth token to authenticate
            :statuscode 200: no error
         """
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to create a new notification."), 403
         return service.create(
             data["label"],
             data["plugin"]["slug"],
@@ -365,6 +368,8 @@ class Notifications(AuthenticatedResource):
            :reqheader Authorization: OAuth token to authenticate
            :statuscode 200: no error
         """
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to update a notification."), 403
         return service.update(
             notification_id,
             data["label"],
@@ -377,6 +382,8 @@ class Notifications(AuthenticatedResource):
         )
 
     def delete(self, notification_id):
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to delete a notification."), 403
         service.delete(notification_id)
         return {"result": True}
 

--- a/lemur/pending_certificates/views.py
+++ b/lemur/pending_certificates/views.py
@@ -9,7 +9,7 @@ from flask import Blueprint, g, make_response, jsonify
 from flask_restful import Api, reqparse, inputs
 
 from lemur.auth.service import AuthenticatedResource
-from lemur.auth.permissions import CertificatePermission
+from lemur.auth.permissions import CertificatePermission, StrictRolePermission
 
 from lemur.common.schema import validate_schema
 from lemur.common.utils import paginated_parser
@@ -546,6 +546,8 @@ class PendingCertificatesUpload(AuthenticatedResource):
            :statuscode 200: no error
 
         """
+        if not StrictRolePermission().can():
+            return dict(message="You are not authorized to upload a pending certificate."), 403
         return service.upload(pending_certificate_id, **data)
 
 

--- a/lemur/roles/views.py
+++ b/lemur/roles/views.py
@@ -93,8 +93,8 @@ class RolesList(AuthenticatedResource):
         args["user"] = g.current_user
         return service.render(args)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(role_input_schema, role_output_schema)
+    @admin_permission.require(http_exception=403)
     def post(self, data=None):
         """
         .. http:post:: /roles

--- a/lemur/sources/views.py
+++ b/lemur/sources/views.py
@@ -92,8 +92,8 @@ class SourcesList(AuthenticatedResource):
         args = parser.parse_args()
         return service.render(args)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(source_input_schema, source_output_schema)
+    @admin_permission.require(http_exception=403)
     def post(self, data=None):
         """
         .. http:post:: /sources
@@ -224,8 +224,8 @@ class Sources(AuthenticatedResource):
         """
         return service.get(source_id)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(source_input_schema, source_output_schema)
+    @admin_permission.require(http_exception=403)
     def put(self, source_id, data=None):
         """
         .. http:put:: /sources/1

--- a/lemur/tests/test_destinations.py
+++ b/lemur/tests/test_destinations.py
@@ -65,7 +65,7 @@ def test_destination_post_(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),
@@ -119,7 +119,7 @@ def test_destination_patch(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),

--- a/lemur/tests/test_roles.py
+++ b/lemur/tests/test_roles.py
@@ -182,7 +182,7 @@ def test_role_patch(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),

--- a/lemur/tests/test_sources.py
+++ b/lemur/tests/test_sources.py
@@ -215,7 +215,7 @@ def test_source_post_(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),
@@ -280,7 +280,7 @@ def test_sources_list_get(client, source_plugin, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),

--- a/lemur/tests/test_users.py
+++ b/lemur/tests/test_users.py
@@ -59,7 +59,7 @@ def test_user_post_(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),
@@ -107,7 +107,7 @@ def test_user_patch(client, token, status):
 @pytest.mark.parametrize(
     "token,status",
     [
-        (VALID_USER_HEADER_TOKEN, 403),
+        (VALID_USER_HEADER_TOKEN, 400),
         (VALID_ADMIN_HEADER_TOKEN, 400),
         (VALID_ADMIN_API_TOKEN, 400),
         ("", 401),

--- a/lemur/users/service.py
+++ b/lemur/users/service.py
@@ -18,6 +18,9 @@ from lemur.logs import service as log_service
 from lemur.users.models import User, TemporaryBreakGlassGrant
 
 
+STRICT_ENFORCEMENT_DEFAULT_ROLES = ["admin", "operator", "read-only"]
+
+
 def create(username, password, email, active, profile_picture, roles):
     """
     Create a new user
@@ -30,6 +33,11 @@ def create(username, password, email, active, profile_picture, roles):
     :param roles:
     :return:
     """
+    strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", False)
+    if strict_role_enforcement and not any(role.name in STRICT_ENFORCEMENT_DEFAULT_ROLES for role in roles):
+        return dict(message="Default role required, user needs least one of the following roles assigned: admin, "
+                            "operator, read-only"), 400
+
     user = User(
         password=password,
         username=username,
@@ -54,6 +62,11 @@ def update(user_id, username, email, active, profile_picture, roles):
     :param roles:
     :return:
     """
+    strict_role_enforcement = current_app.config.get("LEMUR_STRICT_ROLE_ENFORCEMENT", False)
+    if strict_role_enforcement and not any(role.name in STRICT_ENFORCEMENT_DEFAULT_ROLES for role in roles):
+        return dict(message="Default role required, user needs least one of the following roles assigned: admin, "
+                            "operator, read-only"), 400
+
     user = get(user_id)
     user.username = username
     user.email = email

--- a/lemur/users/views.py
+++ b/lemur/users/views.py
@@ -96,8 +96,8 @@ class UsersList(AuthenticatedResource):
         args = parser.parse_args()
         return service.render(args)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(user_input_schema, user_output_schema)
+    @admin_permission.require(http_exception=403)
     def post(self, data=None):
         """
         .. http:post:: /users
@@ -215,8 +215,8 @@ class Users(AuthenticatedResource):
         """
         return service.get(user_id)
 
-    @admin_permission.require(http_exception=403)
     @validate_schema(user_input_schema, user_output_schema)
+    @admin_permission.require(http_exception=403)
     def put(self, user_id, data=None):
         """
         .. http:put:: /users/1

--- a/local/src/lemur.conf.py
+++ b/local/src/lemur.conf.py
@@ -216,6 +216,10 @@ LEMUR_DEFAULT_AUTHORITY = str(os.environ.get("LEMUR_DEFAULT_AUTHORITY", "Example
 
 LEMUR_DEFAULT_ROLE = "operator"
 
+# Restrict authority creation and sensitive operations to admin/operator roles
+ADMIN_ONLY_AUTHORITY_CREATION = True
+LEMUR_STRICT_ROLE_ENFORCEMENT = True
+
 ACTIVE_PROVIDERS = []
 METRIC_PROVIDERS = []
 


### PR DESCRIPTION
## Summary

Cherry-pick of [Netflix/lemur#4538](https://github.com/Netflix/lemur/pull/4538) — fixes access control vulnerabilities (issue #4518) from upstream.

**Upstream commit:** `dca80032` (merged 2023-08-31)

- Added missing permission checks on authorities, certificates, destinations, domains, notifications, pending certificates, roles, sources, and users views
- Added `AuthorityCreatorPermission` class (respects `ADMIN_ONLY_AUTHORITY_CREATION` config flag)
- Added `StrictRolePermission` class (respects `LEMUR_STRICT_ROLE_ENFORCEMENT` config flag)
- Restricts authority creation to admins when configured

**Part of RDNA-918** (upstream Netflix/lemur security cherry-pick initiative).

## Conflict resolution

One conflict in `lemur/authorities/views.py` — import line and POST permission check. Resolved by adding `AuthorityCreatorPermission` to `lemur/auth/permissions.py` (was dropped during auto-merge) and taking upstream's permission guard in the POST handler.

Also fixed deprecated pip egg-fragment syntax in `Dockerfile` (`file://...#egg=` → `-e ".[extra]"`).

## Test plan

- [x] Syntax check passed on all 11 changed files
- [x] Full test suite: **809 passed, 18 skipped** via Docker (`docker compose up test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)