### PR TITLE
Revert sync chain, add hard kill timeout to sync_source

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -535,7 +535,7 @@ def sync_all_sources():
     return log_data
 
 
-@celery_app.task(soft_time_limit=900, time_limit=1200)
+@celery_app.task(soft_time_limit=7200)
 def sync_source(source):
     """
     This celery task will sync the specified source.

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -505,15 +505,6 @@ def clean_source(source):
 
 
 @celery_app.task()
-def complete_sync_chain():
-    red.delete("sync_chain_active")
-    # Mark sync_all_sources as successful now that all sources have synced
-    function = f"{__name__}.sync_all_sources"
-    red.set(f"{function}.last_success", int(time.time()))
-    metrics.send(f"{function}.success", "counter", 1)
-
-
-@celery_app.task()
 def sync_all_sources():
     """
     This function will sync certificates from all sources. This function triggers one celery task per source.
@@ -534,29 +525,17 @@ def sync_all_sources():
         current_app.logger.debug(log_data)
         return
 
-    # Skip if a previous sync chain is still running
-    if red.get("sync_chain_active"):
-        log_data["message"] = "Skipping: previous sync chain is still running"
-        current_app.logger.warning(log_data)
-        return log_data
-
     sources = validate_sources("all")
-    # Source syncs are heavy, chain them sequentially so they don't flood the queue
-    from celery import chain
-    red.set("sync_chain_active", "1", ex=7200)  # cleared by complete_sync_chain at end of chain, 2h expiry is a safety net
-    tasks = []
     for source in sources:
         log_data["source"] = source.label
         current_app.logger.debug(log_data)
-        tasks.append(sync_source.si(source.label))
-    tasks.append(complete_sync_chain.si())
-    if tasks:
-        chain(*tasks).delay()
+        sync_source.delay(source.label)
 
+    metrics.send(f"{function}.success", "counter", 1)
     return log_data
 
 
-@celery_app.task(soft_time_limit=900)  # fail if a source task gets stuck
+@celery_app.task(soft_time_limit=900, time_limit=1200)
 def sync_source(source):
     """
     This celery task will sync the specified source.


### PR DESCRIPTION
Goes back to upstream Netflix's independent dispatch model for source syncs instead of the sequential chain + Redis guard we added. Each source gets its own celery task, so a stuck source doesn't block the others or starve the queue.

Added time_limit=1200 (hard kill) to sync_source. On Apr 12-13, a stuck `[michelada] AWS IAM` sync blocked all celery tasks for 30+ hours because the soft_time_limit was getting swallowed by AWS retry loops. The hard kill forces the worker process to be replaced when the soft limit fails. Normal syncs complete in 1-14 seconds so 20 min is plenty of headroom and we no longer need the sequential chaining. 

This PR is also part of the ongoing effort to reduce our fork divergence so we can sync with upstream more easily.

Reverts #244 (Redis guard PR is no longer needed).