### PR TITLE
Fix prod image build on master commits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ build-prod-image:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   script:
-    - GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$IMAGE_TAG" /bin/bash .campaigns/build_and_push_image.sh
+    - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$IMAGE_TAG" /bin/bash .campaigns/build_and_push_image.sh
 
 build-prod-image-fips:
   image: $CURRENT_CI_IMAGE
@@ -113,7 +113,7 @@ build-prod-image-fips:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   script:
-    - GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$IMAGE_TAG-fips" /bin/bash .campaigns/build_and_push_image.sh
+    - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=prod GBILITE_IMAGE_TO_BUILD="lemur:$IMAGE_TAG-fips" /bin/bash .campaigns/build_and_push_image.sh
 
 gbilite-get-images:
   image: $CURRENT_CI_IMAGE


### PR DESCRIPTION
The build script needs CHECKOUT_REF to download source from GitHub. Without it, it falls back to IMAGE_TAG (e.g. v107661826-aa5cfff6) which isn't a valid git ref so the zip download fails with exit code 9. Pass CHECKOUT_REF=$CI_COMMIT_SHA like the staging builds already do.

Fixes the build-prod-image failure from #250.