### PR TITLE
Add mutable-latest-prod tag for Conductor

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -39,6 +39,14 @@ docker buildx build \
   .
 ddsign sign registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD --docker-metadata-file ${METADATA_FILE}
 
+# Tag as mutable-latest for Conductor's artifact_reference_latest to resolve.
+# Only for prod non-FIPS builds, matching the convention used by Bazel-built services.
+if [[ $GBILITE_ENV == "prod" && $FIPS_ENABLED == "false" ]]; then
+  crane tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD mutable-latest-prod
+elif [[ $GBILITE_ENV == "prod" && $FIPS_ENABLED == "true" ]]; then
+  crane tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD mutable-latest-prod-fips
+fi
+
 # Output image metadata (required by campaigner)
 cd ../
 echo $IMAGE_TAG > .campaigns/image_info.txt


### PR DESCRIPTION
After pushing a prod image, tags it as mutable-latest-prod (and mutable-latest-prod-fips for FIPS). This matches the convention used by Bazel-built services where GBI creates these tags automatically.

Allows k8s-resources to use artifact_reference_latest(branch="prod") to resolve the latest prod image without having to crane ls and grep through all tags.

Part of RDNA-816.