### PR TITLE
Enable ACME issuer plugin in prod Docker image

### DIFF
--- a/publish/files/disable_plugins.patch
+++ b/publish/files/disable_plugins.patch
@@ -5,8 +5,8 @@
          ],
          "lemur.plugins": [
 -            "verisign_issuer = lemur.plugins.lemur_verisign.plugin:VerisignIssuerPlugin",
--            "acme_issuer = lemur.plugins.lemur_acme.plugin:ACMEIssuerPlugin",
--            "acme_http_issuer = lemur.plugins.lemur_acme.plugin:ACMEHttpIssuerPlugin",
+             "acme_issuer = lemur.plugins.lemur_acme.plugin:ACMEIssuerPlugin",
+             "acme_http_issuer = lemur.plugins.lemur_acme.plugin:ACMEHttpIssuerPlugin",
              "aws_destination = lemur.plugins.lemur_aws.plugin:AWSDestinationPlugin",
              "aws_source = lemur.plugins.lemur_aws.plugin:AWSSourcePlugin",
 -            "aws_s3 = lemur.plugins.lemur_aws.plugin:S3DestinationPlugin",

--- a/publish/files/disable_plugins.patch
+++ b/publish/files/disable_plugins.patch
@@ -1,6 +1,6 @@
 --- setup.py.orig	2025-04-02 17:02:50
 +++ setup.py	2025-04-02 17:03:06
-@@ -140,37 +140,13 @@
+@@ -140,37 +140,15 @@
              "lemur = lemur.manage:main",
          ],
          "lemur.plugins": [


### PR DESCRIPTION
## Summary

- Removes `acme_issuer` and `acme_http_issuer` from `disable_plugins.patch` so the ACME plugin entry points survive into the installed package when the prod image is built
- The ACME plugin was already present in `setup.py` but was being stripped out by this patch at Docker build time, preventing it from loading at runtime

## Test plan

- [ ] Build the prod image and verify `acme-issuer` and `acme-http-issuer` appear in the Lemur UI under authority plugin options
- [ ] Confirm existing DigiCert and Sectigo issuers still function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)