### PR TITLE
Skip staging image builds on master to avoid tag collisions

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -39,8 +39,7 @@ docker buildx build \
   .
 ddsign sign registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD --docker-metadata-file ${METADATA_FILE}
 
-# Tag as mutable-latest for Conductor's artifact_reference_latest to resolve.
-# Only for prod non-FIPS builds, matching the convention used by Bazel-built services.
+# Tag as mutable-latest for Conductor image resolution.
 if [[ $GBILITE_ENV == "prod" && $FIPS_ENABLED == "false" ]]; then
   crane tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD mutable-latest-prod
 elif [[ $GBILITE_ENV == "prod" && $FIPS_ENABLED == "true" ]]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,12 +40,14 @@ test:
     - bandit -r . -ll -ii -x lemur/tests/,docs
     - xvfb-run make test-js
 
+# Staging-signed images only run on non-master branches (PR testing).
+# On master, only prod-signed images are built to avoid tag collisions.
 build-stage-image:
   image: $CURRENT_CI_IMAGE
   stage: build-stage-image
   when: on_success
   rules:
-    - if: ($CI_COMMIT_TAG == null && $GBILITE_GITLAB_ACTION == null)
+    - if: $CI_COMMIT_TAG == null && $CI_COMMIT_BRANCH != "master" && $GBILITE_GITLAB_ACTION == null
   timeout: 2h
   tags: ["arch:amd64"]
   variables:
@@ -61,7 +63,7 @@ build-stage-image-fips:
   stage: build-stage-image-fips
   when: on_success
   rules:
-    - if: ($CI_COMMIT_TAG == null && $GBILITE_GITLAB_ACTION == null)
+    - if: $CI_COMMIT_TAG == null && $CI_COMMIT_BRANCH != "master" && $GBILITE_GITLAB_ACTION == null
   timeout: 2h
   tags: ["arch:amd64"]
   variables:


### PR DESCRIPTION
On master, both staging and prod builds pushed lemur:v{pipeline}-{sha} with different signing, causing the last job to overwrite the tag. Now staging builds only run on non-master branches (for PR testing). On master, only prod-signed images are built.

This means v{pipeline}-{sha} uniquely identifies the prod image on master, so Conductor can resolve the actual build tag from mutable-latest-prod for version visibility in Mosaic/Datadog.

RDNA-816