### PR TITLE
feat(cert-orchestration): add coa-destination-retry plugin with retry_until_healthy flag

### DIFF
--- a/lemur/plugins/lemur_vault_dest/plugin.py
+++ b/lemur/plugins/lemur_vault_dest/plugin.py
@@ -141,13 +141,14 @@ def _upload_with_retry(stub, request, auth_token, retry_timeout_seconds, initial
                 except Exception:
                     pass
             return
-        except grpc.RpcError as exc:
+        except Exception as exc:
             if not _is_retriable_grpc_error(exc):
                 raise
 
             attempt += 1
-            elapsed = time.monotonic() - start
-            if deadline is not None and time.monotonic() >= deadline:
+            now = time.monotonic()
+            elapsed = now - start
+            if deadline is not None and now >= deadline:
                 current_app.logger.error(
                     "COA upload retry deadline exceeded after %d attempt(s): %s",
                     attempt,
@@ -631,7 +632,7 @@ class COADestinationPlugin(DestinationPlugin):
         },
         {
             "name": "retry_timeout_seconds",
-            "type": "str",
+            "type": "int",
             "required": False,
             "validation": check_validation(r"^\d+$"),
             "helpMessage": (
@@ -639,11 +640,11 @@ class COADestinationPlugin(DestinationPlugin):
                 "Set to 0 to retry forever.  Only used when retry_until_healthy "
                 "is true.  Default: 600 (10 minutes)."
             ),
-            "default": "600",
+            "default": 600,
         },
         {
             "name": "retry_initial_wait_seconds",
-            "type": "str",
+            "type": "int",
             "required": False,
             "validation": check_validation(r"^\d+(\.\d+)?$"),
             "helpMessage": (
@@ -651,7 +652,7 @@ class COADestinationPlugin(DestinationPlugin):
                 "Doubles on each attempt, capped at 60 s.  "
                 "Only used when retry_until_healthy is true.  Default: 5."
             ),
-            "default": "5",
+            "default": 5,
         },
     ]
 

--- a/lemur/plugins/lemur_vault_dest/plugin.py
+++ b/lemur/plugins/lemur_vault_dest/plugin.py
@@ -14,7 +14,6 @@ import os
 import re
 import time
 import hvac
-import grpc
 from flask import current_app
 
 from lemur.common.defaults import (
@@ -26,6 +25,7 @@ from lemur.common.defaults import (
     organization,
 )
 from lemur.common.utils import parse_certificate, check_validation
+from lemur.extensions import metrics
 from lemur.plugins.bases import DestinationPlugin
 from lemur.plugins.bases import SourcePlugin
 
@@ -35,6 +35,7 @@ from cryptography.hazmat.backends import default_backend
 from validators.url import url
 
 try:
+    import grpc
     from cert_orchestration_adapter.plugin import create_coa_connection, parse_ca_vendor
     from cert_orchestration_adapter.plugin import (
         parse_certificate as coa_parse_certificate,
@@ -47,6 +48,7 @@ try:
     _COA_AVAILABLE = True
 except ImportError:
     _COA_AVAILABLE = False
+    grpc = None
     _coa_adapter_pb2 = None
 
 # ---------------------------------------------------------------------------
@@ -55,7 +57,7 @@ except ImportError:
 
 # gRPC status codes that indicate the upstream is not yet reachable and the
 # call is safe to retry without risk of duplicate side-effects.
-_RETRIABLE_STATUS_CODES = {grpc.StatusCode.UNAVAILABLE}
+_RETRIABLE_STATUS_CODES = {grpc.StatusCode.UNAVAILABLE} if grpc is not None else set()
 
 # Substrings in the gRPC error detail that confirm a "no healthy upstream"
 # condition.  If any of these appear we know COA simply isn't deployed yet
@@ -76,6 +78,8 @@ def _is_retriable_grpc_error(exc):
     errors – including UNAUTHENTICATED, PERMISSION_DENIED, INVALID_ARGUMENT,
     and INTERNAL – propagate immediately so mis-configuration is surfaced fast.
     """
+    if grpc is None:
+        return False
     if not isinstance(exc, grpc.RpcError):
         return False
     try:
@@ -92,7 +96,7 @@ def _is_retriable_grpc_error(exc):
     return any(sub in detail_lower for sub in _RETRIABLE_DETAIL_SUBSTRINGS)
 
 
-def _upload_with_retry(stub, request, auth_token, retry_timeout_seconds, initial_wait_seconds):
+def _upload_with_retry(stub, request, auth_token, retry_timeout_seconds, initial_wait_seconds, endpoint="unknown"):
     """Call stub.Upload(request) with exponential back-off on retriable errors.
 
     Args:
@@ -103,24 +107,46 @@ def _upload_with_retry(stub, request, auth_token, retry_timeout_seconds, initial
             loop.  Zero or negative means retry forever.
         initial_wait_seconds (float): Wait time before the first retry.
             Each subsequent wait is doubled, capped at 60 s.
+        endpoint (str): Human-readable endpoint label for logs and metrics.
+            Defaults to "unknown".
 
     Raises:
         grpc.RpcError: Re-raises the last gRPC error when the deadline is
             exceeded or when the error is not retriable.
     """
-    deadline = time.monotonic() + retry_timeout_seconds if retry_timeout_seconds > 0 else None
+    start = time.monotonic()
+    deadline = start + retry_timeout_seconds if retry_timeout_seconds > 0 else None
     wait = max(initial_wait_seconds, 1.0)
     attempt = 0
 
     while True:
         try:
             stub.Upload(request=request, metadata=[auth_token])
+            if attempt > 0:
+                current_app.logger.info(
+                    {
+                        "message": "COA upload succeeded after retries",
+                        "attempt_count": attempt,
+                        "endpoint": endpoint,
+                        "total_elapsed_seconds": round(time.monotonic() - start, 2),
+                    }
+                )
+                try:
+                    metrics.send(
+                        "lemur.plugins.coa.retry_success",
+                        "counter",
+                        1,
+                        metric_tags={"host": endpoint},
+                    )
+                except Exception:
+                    pass
             return
         except grpc.RpcError as exc:
             if not _is_retriable_grpc_error(exc):
                 raise
 
             attempt += 1
+            elapsed = time.monotonic() - start
             if deadline is not None and time.monotonic() >= deadline:
                 current_app.logger.error(
                     "COA upload retry deadline exceeded after %d attempt(s): %s",
@@ -130,11 +156,24 @@ def _upload_with_retry(stub, request, auth_token, retry_timeout_seconds, initial
                 raise
 
             current_app.logger.warning(
-                "COA gRPC UNAVAILABLE (attempt %d), retrying in %.1f s: %s",
-                attempt,
-                wait,
-                exc.details(),
+                {
+                    "message": "COA gRPC UNAVAILABLE — will retry",
+                    "attempt": attempt,
+                    "wait_seconds": round(wait, 1),
+                    "total_elapsed_seconds": round(elapsed, 2),
+                    "endpoint": endpoint,
+                    "grpc_detail": exc.details(),
+                }
             )
+            try:
+                metrics.send(
+                    "lemur.plugins.coa.retry_attempt",
+                    "counter",
+                    1,
+                    metric_tags={"host": endpoint},
+                )
+            except Exception:
+                pass
             time.sleep(wait)
             wait = min(wait * 2, 60.0)
 
@@ -524,7 +563,7 @@ class COADestinationPlugin(DestinationPlugin):
     """
 
     title = "Cert Orchestration Adapter (with retry)"
-    slug = "coa-destination-retrying"
+    slug = "coa-destination-retry"
     description = (
         "Uploads certificates to the Cert Orchestration Adapter over gRPC.  "
         "When retry_until_healthy is enabled the plugin retries on "
@@ -552,7 +591,7 @@ class COADestinationPlugin(DestinationPlugin):
         },
         {
             "name": "port",
-            "type": "str",
+            "type": "int",
             "required": True,
             "validation": check_validation(r"^\d+$"),
             "helpMessage": "COA service gRPC port.",
@@ -645,12 +684,6 @@ class COADestinationPlugin(DestinationPlugin):
             )
             raise
 
-        if not paths_list:
-            current_app.logger.error(
-                "COADestinationPlugin: no paths configured for certificate upload"
-            )
-            return
-
         parsed_crt = coa_parse_certificate(body)
         parsed_chain = coa_parse_certificate(cert_chain)
         ca_vendor = parse_ca_vendor(parsed_chain)
@@ -662,6 +695,12 @@ class COADestinationPlugin(DestinationPlugin):
         )
 
         with channel:
+            if not paths_list:
+                current_app.logger.error(
+                    "COADestinationPlugin: no paths configured for certificate upload"
+                )
+                return
+
             for path in paths_list:
                 vault_path = os.path.join(path, crt_name)
                 current_app.logger.info(
@@ -688,6 +727,7 @@ class COADestinationPlugin(DestinationPlugin):
                         auth_token=auth_token,
                         retry_timeout_seconds=retry_timeout,
                         initial_wait_seconds=initial_wait,
+                        endpoint=host,
                     )
                 else:
                     try:

--- a/lemur/plugins/lemur_vault_dest/plugin.py
+++ b/lemur/plugins/lemur_vault_dest/plugin.py
@@ -12,7 +12,9 @@
 
 import os
 import re
+import time
 import hvac
+import grpc
 from flask import current_app
 
 from lemur.common.defaults import (
@@ -31,6 +33,110 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
 from validators.url import url
+
+try:
+    from cert_orchestration_adapter.plugin import create_coa_connection, parse_ca_vendor
+    from cert_orchestration_adapter.plugin import (
+        parse_certificate as coa_parse_certificate,
+        common_name as coa_common_name,
+        get_key_type_from_certificate,
+    )
+    from domains.cert_orchestration.libs.pb.cert_orchestration_adapter import (
+        service_pb2 as _coa_adapter_pb2,
+    )
+    _COA_AVAILABLE = True
+except ImportError:
+    _COA_AVAILABLE = False
+    _coa_adapter_pb2 = None
+
+# ---------------------------------------------------------------------------
+# Retry helpers for gRPC UNAVAILABLE errors
+# ---------------------------------------------------------------------------
+
+# gRPC status codes that indicate the upstream is not yet reachable and the
+# call is safe to retry without risk of duplicate side-effects.
+_RETRIABLE_STATUS_CODES = {grpc.StatusCode.UNAVAILABLE}
+
+# Substrings in the gRPC error detail that confirm a "no healthy upstream"
+# condition.  If any of these appear we know COA simply isn't deployed yet
+# and retrying is the right behaviour.
+_RETRIABLE_DETAIL_SUBSTRINGS = (
+    "no healthy upstream",
+    "upstream connect error",
+    "connection refused",
+    "failed to connect",
+)
+
+
+def _is_retriable_grpc_error(exc):
+    """Return True if *exc* is a gRPC error that should be retried.
+
+    Only retries on UNAVAILABLE status where the detail string indicates that
+    the upstream is unreachable (e.g. COA not yet deployed).  All other gRPC
+    errors – including UNAUTHENTICATED, PERMISSION_DENIED, INVALID_ARGUMENT,
+    and INTERNAL – propagate immediately so mis-configuration is surfaced fast.
+    """
+    if not isinstance(exc, grpc.RpcError):
+        return False
+    try:
+        code = exc.code()
+    except Exception:
+        return False
+    if code not in _RETRIABLE_STATUS_CODES:
+        return False
+    try:
+        detail = exc.details() or ""
+    except Exception:
+        detail = ""
+    detail_lower = detail.lower()
+    return any(sub in detail_lower for sub in _RETRIABLE_DETAIL_SUBSTRINGS)
+
+
+def _upload_with_retry(stub, request, auth_token, retry_timeout_seconds, initial_wait_seconds):
+    """Call stub.Upload(request) with exponential back-off on retriable errors.
+
+    Args:
+        stub: gRPC stub with an Upload method.
+        request: The CertificateUploadRequest protobuf message.
+        auth_token: (key, value) tuple for the gRPC call metadata.
+        retry_timeout_seconds (float): Wall-clock deadline for the entire retry
+            loop.  Zero or negative means retry forever.
+        initial_wait_seconds (float): Wait time before the first retry.
+            Each subsequent wait is doubled, capped at 60 s.
+
+    Raises:
+        grpc.RpcError: Re-raises the last gRPC error when the deadline is
+            exceeded or when the error is not retriable.
+    """
+    deadline = time.monotonic() + retry_timeout_seconds if retry_timeout_seconds > 0 else None
+    wait = max(initial_wait_seconds, 1.0)
+    attempt = 0
+
+    while True:
+        try:
+            stub.Upload(request=request, metadata=[auth_token])
+            return
+        except grpc.RpcError as exc:
+            if not _is_retriable_grpc_error(exc):
+                raise
+
+            attempt += 1
+            if deadline is not None and time.monotonic() >= deadline:
+                current_app.logger.error(
+                    "COA upload retry deadline exceeded after %d attempt(s): %s",
+                    attempt,
+                    exc.details(),
+                )
+                raise
+
+            current_app.logger.warning(
+                "COA gRPC UNAVAILABLE (attempt %d), retrying in %.1f s: %s",
+                attempt,
+                wait,
+                exc.details(),
+            )
+            time.sleep(wait)
+            wait = min(wait * 2, 60.0)
 
 
 class VaultSourcePlugin(SourcePlugin):
@@ -385,3 +491,212 @@ def get_secret(client, mount, path):
         pass
     finally:
         return result
+
+
+# ---------------------------------------------------------------------------
+# COA (Cert Orchestration Adapter) destination plugin
+# ---------------------------------------------------------------------------
+
+class COADestinationPlugin(DestinationPlugin):
+    """Destination plugin that delivers certificates to the Cert Orchestration
+    Adapter (COA) service over gRPC.
+
+    Extends the base COA destination with a ``retry_until_healthy`` option: when
+    enabled, a gRPC UNAVAILABLE / "no healthy upstream" error causes the plugin
+    to retry with exponential back-off instead of failing immediately.  This is
+    useful during initial cluster bootstrapping when COA may not yet be deployed.
+
+    The plugin delegates connection setup to
+    ``cert_orchestration_adapter.plugin.create_coa_connection`` so that auth
+    (JWT / Ticino), channel setup, and path parsing stay in one place.
+
+    Configuration example (per-destination options)::
+
+        hostname: cert-orchestration-adapter.cert-orchestration.<env>.fabric.dog
+        port: 3000
+        audience: cert-orchestration-adapter
+        paths: /secret/certs/my-app
+        use_xdcgw: false
+        use_ticino: false
+        retry_until_healthy: true   # <-- new flag
+        retry_timeout_seconds: 600  # give up after 10 min (0 = retry forever)
+        retry_initial_wait_seconds: 5
+    """
+
+    title = "Cert Orchestration Adapter (with retry)"
+    slug = "coa-destination-retrying"
+    description = (
+        "Uploads certificates to the Cert Orchestration Adapter over gRPC.  "
+        "When retry_until_healthy is enabled the plugin retries on "
+        "UNAVAILABLE / 'no healthy upstream' errors with exponential back-off."
+    )
+
+    author = "Datadog Runtime DNA"
+    author_url = "https://github.com/DataDog/lemur"
+
+    options = [
+        {
+            "name": "audience",
+            "type": "str",
+            "required": True,
+            "helpMessage": "JWT audience claim for authenticating with the COA service.",
+        },
+        {
+            "name": "hostname",
+            "type": "str",
+            "required": True,
+            "validation": check_validation("^.*.fabric.dog|localhost$"),
+            "helpMessage": (
+                "COA service hostname.  Must be a Fabric DNS name or localhost."
+            ),
+        },
+        {
+            "name": "port",
+            "type": "str",
+            "required": True,
+            "validation": check_validation(r"^\d+$"),
+            "helpMessage": "COA service gRPC port.",
+        },
+        {
+            "name": "paths",
+            "type": "str",
+            "required": True,
+            "validation": check_validation(r"^(/[\w-]+)+(,[/\w-]+)*$"),
+            "helpMessage": "Comma-delimited list of Vault paths to write each certificate to.",
+        },
+        {
+            "name": "use_xdcgw",
+            "type": "bool",
+            "required": False,
+            "helpMessage": "Route the request through the Cross-DC Gateway.",
+            "default": False,
+        },
+        {
+            "name": "use_ticino",
+            "type": "bool",
+            "required": False,
+            "helpMessage": "Use Ticino tokens for cross-DC internal service auth.",
+            "default": False,
+        },
+        {
+            "name": "retry_until_healthy",
+            "type": "bool",
+            "required": False,
+            "helpMessage": (
+                "When true, retry the gRPC call with exponential back-off on "
+                "UNAVAILABLE / 'no healthy upstream' errors.  All other errors "
+                "are raised immediately.  Useful when COA may not be deployed "
+                "yet on the target cluster."
+            ),
+            "default": False,
+        },
+        {
+            "name": "retry_timeout_seconds",
+            "type": "str",
+            "required": False,
+            "validation": check_validation(r"^\d+$"),
+            "helpMessage": (
+                "How long (in seconds) to keep retrying before giving up.  "
+                "Set to 0 to retry forever.  Only used when retry_until_healthy "
+                "is true.  Default: 600 (10 minutes)."
+            ),
+            "default": "600",
+        },
+        {
+            "name": "retry_initial_wait_seconds",
+            "type": "str",
+            "required": False,
+            "validation": check_validation(r"^\d+(\.\d+)?$"),
+            "helpMessage": (
+                "Initial back-off delay in seconds before the first retry.  "
+                "Doubles on each attempt, capped at 60 s.  "
+                "Only used when retry_until_healthy is true.  Default: 5."
+            ),
+            "default": "5",
+        },
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super(COADestinationPlugin, self).__init__(*args, **kwargs)
+
+    def upload(self, name, body, private_key, cert_chain, options, **kwargs):
+        """Upload a certificate to COA.
+
+        When *retry_until_healthy* is set the call is retried with exponential
+        back-off whenever gRPC returns UNAVAILABLE with a detail string that
+        looks like "no healthy upstream" (or similar).  All other gRPC errors
+        propagate immediately.
+        """
+        if not _COA_AVAILABLE:
+            raise RuntimeError(
+                "cert_orchestration_adapter wheel is not installed; "
+                "cannot use COADestinationPlugin."
+            )
+
+        retry_until_healthy = self.get_option("retry_until_healthy", options)
+        retry_timeout = float(self.get_option("retry_timeout_seconds", options) or 600)
+        initial_wait = float(self.get_option("retry_initial_wait_seconds", options) or 5)
+
+        try:
+            stub, channel, paths_list, host, auth_token = create_coa_connection(self, options)
+        except Exception as exc:
+            current_app.logger.error(
+                "Failed to create COA gRPC connection: %s", exc, exc_info=True
+            )
+            raise
+
+        if not paths_list:
+            current_app.logger.error(
+                "COADestinationPlugin: no paths configured for certificate upload"
+            )
+            return
+
+        parsed_crt = coa_parse_certificate(body)
+        parsed_chain = coa_parse_certificate(cert_chain)
+        ca_vendor = parse_ca_vendor(parsed_chain)
+        key_type = get_key_type_from_certificate(body)
+        crt_name = "{cn}_{vendor}_{ktype}".format(
+            cn=coa_common_name(parsed_crt),
+            vendor=ca_vendor,
+            ktype=key_type,
+        )
+
+        with channel:
+            for path in paths_list:
+                vault_path = os.path.join(path, crt_name)
+                current_app.logger.info(
+                    {
+                        "message": "Uploading certificate via COADestinationPlugin",
+                        "name": name,
+                        "endpoint": host,
+                        "path": vault_path,
+                        "retry_until_healthy": retry_until_healthy,
+                    }
+                )
+
+                request = _coa_adapter_pb2.CertificateUploadRequest(
+                    certificate=body,
+                    intermediate=cert_chain,
+                    private_key=private_key,
+                    vault_path=vault_path,
+                )
+
+                if retry_until_healthy:
+                    _upload_with_retry(
+                        stub=stub,
+                        request=request,
+                        auth_token=auth_token,
+                        retry_timeout_seconds=retry_timeout,
+                        initial_wait_seconds=initial_wait,
+                    )
+                else:
+                    try:
+                        stub.Upload(request=request, metadata=[auth_token])
+                    except Exception as exc:
+                        current_app.logger.error(
+                            "COA gRPC upload failed for path %s: %s",
+                            vault_path,
+                            exc,
+                            exc_info=True,
+                        )
+                        raise

--- a/lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py
+++ b/lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py
@@ -237,9 +237,6 @@ class TestIsRetriableGrpcError:
 # under every pytest import mode.  patch.object is always safe regardless of
 # sys.modules state.
 
-import time as _time_module  # noqa: E402
-
-
 class TestUploadWithRetry:
 
     AUTH_TOKEN = ("authorization", "Bearer tok")

--- a/lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py
+++ b/lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for the gRPC retry helpers in lemur_vault_dest/plugin.py:
+  - _is_retriable_grpc_error
+  - _upload_with_retry
+
+Strategy: we load plugin.py directly via importlib (bypassing the lemur package
+init chain) after pre-populating sys.modules with lightweight stubs for every
+import that plugin.py touches.  This means the test is self-contained and does
+not require a Postgres database, LDAP server, or the full Lemur application
+stack.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import grpc
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Pre-populate sys.modules with stubs for everything plugin.py imports
+# ---------------------------------------------------------------------------
+
+def _stub(name, **attrs):
+    """Register a stub module with optional attributes."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _ensure_parents(dotted):
+    """Make sure every parent package of *dotted* is also a stub."""
+    parts = dotted.split(".")
+    for i in range(1, len(parts) + 1):
+        fqn = ".".join(parts[:i])
+        if fqn not in sys.modules:
+            _stub(fqn)
+
+
+_STUB_SPECS = {
+    # lemur internals that plugin.py imports at module level
+    "lemur.common.defaults": dict(
+        common_name=MagicMock(),
+        country=MagicMock(),
+        state=MagicMock(),
+        location=MagicMock(),
+        organizational_unit=MagicMock(),
+        organization=MagicMock(),
+    ),
+    "lemur.common.utils": dict(
+        parse_certificate=MagicMock(),
+        check_validation=MagicMock(return_value=True),
+    ),
+    "lemur.plugins.bases": dict(
+        DestinationPlugin=type("DestinationPlugin", (), {
+            "__init__": lambda self, *a, **kw: None,
+            "get_option": lambda self, name, opts: None,
+        }),
+        SourcePlugin=type("SourcePlugin", (), {
+            "__init__": lambda self, *a, **kw: None,
+            "get_option": lambda self, name, opts: None,
+        }),
+    ),
+    # third-party / optional deps
+    "hvac": dict(Client=MagicMock()),
+    "validators": {},
+    "validators.url": dict(url=lambda u: True),
+    "cryptography": {},
+    "cryptography.x509": dict(
+        load_pem_x509_certificate=MagicMock(),
+        DNSName=MagicMock(),
+        oid=MagicMock(),
+        extensions=types.SimpleNamespace(ExtensionNotFound=Exception),
+    ),
+    "cryptography.hazmat": {},
+    "cryptography.hazmat.backends": dict(default_backend=MagicMock()),
+    # Flask — we only need the current_app proxy; tests will patch it
+    "flask": dict(current_app=MagicMock()),
+    # COA adapter — plugin.py imports grpc INSIDE the try/except block that
+    # also imports these COA symbols.  If any import in the block fails the
+    # except handler sets grpc=None, disabling all retry logic.  We therefore
+    # provide real-looking stubs for every symbol the try block imports so the
+    # try succeeds and grpc remains the real module.
+    "cert_orchestration_adapter": {},
+    "cert_orchestration_adapter.plugin": dict(
+        create_coa_connection=MagicMock(),
+        parse_ca_vendor=MagicMock(),
+        parse_certificate=MagicMock(),
+        common_name=MagicMock(),
+        get_key_type_from_certificate=MagicMock(),
+    ),
+    "domains": {},
+    "domains.cert_orchestration": {},
+    "domains.cert_orchestration.libs": {},
+    "domains.cert_orchestration.libs.pb": {},
+    "domains.cert_orchestration.libs.pb.cert_orchestration_adapter": {},
+    "domains.cert_orchestration.libs.pb.cert_orchestration_adapter.service_pb2": dict(
+        CertificateUploadRequest=MagicMock(),
+    ),
+}
+
+for _fqn, _attrs in _STUB_SPECS.items():
+    _ensure_parents(_fqn)
+    _stub(_fqn, **_attrs)
+
+# Also ensure grpc is the real module (not stubbed)
+assert "grpc" in sys.modules or importlib.util.find_spec("grpc") is not None
+
+
+# ---------------------------------------------------------------------------
+# Load plugin.py directly (without going through lemur's package __init__)
+# ---------------------------------------------------------------------------
+
+_PLUGIN_PATH = os.path.join(
+    os.path.dirname(__file__),  # …/lemur_vault_dest/tests/
+    "..",                       # …/lemur_vault_dest/
+    "plugin.py",
+)
+_PLUGIN_PATH = os.path.abspath(_PLUGIN_PATH)
+
+_spec = importlib.util.spec_from_file_location(
+    "lemur_vault_dest_plugin_under_test", _PLUGIN_PATH
+)
+_plugin_mod = importlib.util.module_from_spec(_spec)
+# Register in sys.modules so that patch() can look it up by name.
+sys.modules[_spec.name] = _plugin_mod
+_spec.loader.exec_module(_plugin_mod)
+
+_is_retriable_grpc_error = _plugin_mod._is_retriable_grpc_error
+_upload_with_retry = _plugin_mod._upload_with_retry
+
+# Convenience references for patching inside the loaded module.
+# patch() resolves "module_name.attr" via sys.modules, so the module must be
+# registered (done above).  For nested attributes like time.sleep we patch
+# the attribute on the `time` module object that the plugin holds.
+_plugin_time = _plugin_mod.time   # the `time` module as imported by plugin.py
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeRpcError(grpc.RpcError):
+    """Minimal grpc.RpcError subclass whose code() and details() are controllable.
+
+    grpc.RpcError itself only inherits from Exception — it has no code() or
+    details() methods.  Real gRPC errors inherit from both grpc.RpcError and
+    grpc.Call (which adds those methods).  Using MagicMock(spec=grpc.RpcError)
+    blocks .code() calls because that attribute isn't on grpc.RpcError.
+
+    Subclassing grpc.RpcError directly (rather than using MagicMock) means
+    isinstance(exc, grpc.RpcError) returns True and .code()/.details() work.
+    """
+
+    def __init__(self, code, detail):
+        self._code = code
+        self._detail = detail
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._detail
+
+
+def make_rpc_error(code, detail):
+    """Build a grpc.RpcError instance with the given status code and detail."""
+    return _FakeRpcError(code, detail)
+
+
+# ---------------------------------------------------------------------------
+# _is_retriable_grpc_error tests
+# ---------------------------------------------------------------------------
+
+class TestIsRetriableGrpcError:
+
+    def test_unavailable_no_healthy_upstream_returns_true(self):
+        err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
+        assert _is_retriable_grpc_error(err) is True
+
+    def test_unavailable_upstream_connect_error_returns_true(self):
+        err = make_rpc_error(
+            grpc.StatusCode.UNAVAILABLE,
+            "upstream connect error or disconnect/reset before headers",
+        )
+        assert _is_retriable_grpc_error(err) is True
+
+    def test_unavailable_connection_refused_returns_true(self):
+        err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "connection refused")
+        assert _is_retriable_grpc_error(err) is True
+
+    def test_unavailable_failed_to_connect_returns_true(self):
+        err = make_rpc_error(
+            grpc.StatusCode.UNAVAILABLE, "failed to connect to all addresses"
+        )
+        assert _is_retriable_grpc_error(err) is True
+
+    def test_unavailable_mixed_case_returns_true(self):
+        """Detail matching is case-insensitive."""
+        err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "No Healthy Upstream")
+        assert _is_retriable_grpc_error(err) is True
+
+    def test_unavailable_unrelated_detail_returns_false(self):
+        err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "quota exceeded")
+        assert _is_retriable_grpc_error(err) is False
+
+    def test_unauthenticated_returns_false(self):
+        err = make_rpc_error(grpc.StatusCode.UNAUTHENTICATED, "no healthy upstream")
+        assert _is_retriable_grpc_error(err) is False
+
+    def test_permission_denied_returns_false(self):
+        err = make_rpc_error(grpc.StatusCode.PERMISSION_DENIED, "no healthy upstream")
+        assert _is_retriable_grpc_error(err) is False
+
+    def test_internal_returns_false(self):
+        err = make_rpc_error(grpc.StatusCode.INTERNAL, "no healthy upstream")
+        assert _is_retriable_grpc_error(err) is False
+
+    def test_non_grpc_exception_returns_false(self):
+        assert _is_retriable_grpc_error(ValueError("something went wrong")) is False
+
+    def test_plain_exception_returns_false(self):
+        assert _is_retriable_grpc_error(Exception("connection refused")) is False
+
+
+# ---------------------------------------------------------------------------
+# _upload_with_retry tests
+# ---------------------------------------------------------------------------
+
+# We patch current_app directly on the module object (not by name), because the
+# plugin is loaded under a synthetic module name that may not be in sys.modules
+# under every pytest import mode.  patch.object is always safe regardless of
+# sys.modules state.
+
+import time as _time_module  # noqa: E402
+
+
+class TestUploadWithRetry:
+
+    AUTH_TOKEN = ("authorization", "Bearer tok")
+
+    def _monotonic_seq(self, n=50):
+        """Return a list of n monotonically increasing float values starting at 0.0.
+
+        The plugin calls time.monotonic() in multiple places:
+          - Once at start to record `start` and compute `deadline`.
+          - Twice per failure: once for `elapsed = monotonic() - start` and
+            once for the deadline check `monotonic() >= deadline`.
+          - Once on success after ≥1 retry: for the success log message.
+        We always pass more values than needed so tests never hit StopIteration.
+        """
+        return [float(i) for i in range(n)]
+
+    def test_success_on_first_attempt(self):
+        """stub.Upload called exactly once; no sleep.
+
+        First attempt succeeds (attempt==0), so the success log is not emitted
+        and monotonic() is called only once (for `start`).
+        """
+        stub = MagicMock()
+        stub.Upload.side_effect = [MagicMock()]
+        request = MagicMock()
+
+        with patch.object(_plugin_mod, "current_app"):
+            with patch.object(_plugin_time, "sleep") as mock_sleep:
+                with patch.object(_plugin_time, "monotonic", side_effect=self._monotonic_seq()):
+                    _upload_with_retry(
+                        stub, request, self.AUTH_TOKEN,
+                        retry_timeout_seconds=10, initial_wait_seconds=1,
+                    )
+
+        stub.Upload.assert_called_once_with(request=request, metadata=[self.AUTH_TOKEN])
+        mock_sleep.assert_not_called()
+
+    def test_succeeds_after_two_unavailable_failures(self):
+        """stub.Upload called 3 times when first two raise retriable UNAVAILABLE.
+
+        monotonic() call pattern (deadline=9999):
+          [0] start; [1] elapsed1; [2] deadline1 check; [3] elapsed2; [4] deadline2 check;
+          [5] success log (attempt>0).
+        """
+        unavailable_err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
+        stub = MagicMock()
+        stub.Upload.side_effect = [unavailable_err, unavailable_err, MagicMock()]
+        request = MagicMock()
+
+        with patch.object(_plugin_mod, "current_app"):
+            with patch.object(_plugin_time, "sleep") as mock_sleep:
+                with patch.object(_plugin_time, "monotonic", side_effect=self._monotonic_seq()):
+                    _upload_with_retry(
+                        stub, request, self.AUTH_TOKEN,
+                        retry_timeout_seconds=9999, initial_wait_seconds=1,
+                    )
+
+        assert stub.Upload.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_non_retriable_error_raises_immediately(self):
+        """UNAUTHENTICATED propagates after one call — no retry, no sleep."""
+        unauth_err = make_rpc_error(grpc.StatusCode.UNAUTHENTICATED, "invalid token")
+        stub = MagicMock()
+        stub.Upload.side_effect = unauth_err
+        request = MagicMock()
+
+        with patch.object(_plugin_mod, "current_app"):
+            with patch.object(_plugin_time, "sleep") as mock_sleep:
+                with pytest.raises(grpc.RpcError):
+                    _upload_with_retry(
+                        stub, request, self.AUTH_TOKEN,
+                        retry_timeout_seconds=10, initial_wait_seconds=1,
+                    )
+
+        stub.Upload.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_timeout_raises_last_grpc_error(self):
+        """After the deadline passes the last retriable error is re-raised.
+
+        monotonic() call pattern (deadline = start + 5 = 5):
+          [0] start → deadline=5;
+          [1] elapsed (= 1.0, elapsed=1.0);
+          [2] deadline check → 2.0 < 5 → NOT past deadline yet.
+
+        We need the SECOND failure's deadline check to be >= 5. So we return
+        a sequence where after the second failure the deadline check value >= 5.
+        Concretely: [0, 1, 1, 6, 10] gives:
+          monotonic[0]=0 → deadline=5
+          monotonic[1]=1 → elapsed1=1
+          monotonic[2]=1 → 1 < 5, not expired → sleep → retry
+          monotonic[3]=6 → elapsed2=6
+          monotonic[4]=10 → 10 >= 5 → EXPIRED → raise
+        """
+        unavailable_err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
+        stub = MagicMock()
+        # Keep raising on every call so we can control exactly when timeout hits
+        stub.Upload.side_effect = unavailable_err
+        request = MagicMock()
+
+        # Let the first failure pass (not timed out) and the second fail with timeout.
+        monotonic_values = [0.0, 1.0, 1.0, 6.0, 10.0] + [10.0] * 5
+
+        with patch.object(_plugin_mod, "current_app"):
+            with patch.object(_plugin_time, "sleep"):
+                with patch.object(_plugin_time, "monotonic", side_effect=monotonic_values):
+                    with pytest.raises(grpc.RpcError):
+                        _upload_with_retry(
+                            stub, request, self.AUTH_TOKEN,
+                            retry_timeout_seconds=5, initial_wait_seconds=1,
+                        )
+
+        # Two Upload calls: first fails+retries, second fails+times out.
+        assert stub.Upload.call_count == 2
+
+    def test_exponential_backoff_with_cap(self):
+        """sleep() called with 1→2→4→8→16 for 5 retriable failures then success.
+
+        monotonic() calls: 1 (start) + 5*2 (per failure: elapsed+deadline check) +
+        1 (success log, because attempt>0) = 12 total.
+        """
+        unavailable_err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
+        stub = MagicMock()
+        stub.Upload.side_effect = [
+            unavailable_err,
+            unavailable_err,
+            unavailable_err,
+            unavailable_err,
+            unavailable_err,
+            MagicMock(),
+        ]
+        request = MagicMock()
+
+        with patch.object(_plugin_mod, "current_app"):
+            with patch.object(_plugin_time, "sleep") as mock_sleep:
+                with patch.object(_plugin_time, "monotonic", side_effect=self._monotonic_seq()):
+                    _upload_with_retry(
+                        stub, request, self.AUTH_TOKEN,
+                        retry_timeout_seconds=9999, initial_wait_seconds=1,
+                    )
+
+        sleep_args = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_args == [1.0, 2.0, 4.0, 8.0, 16.0]
+
+    def test_exponential_backoff_caps_at_60(self):
+        """Wait time never exceeds 60 s regardless of retry count.
+
+        8 failures → expected waits: 1, 2, 4, 8, 16, 32, 60, 60.
+        monotonic() calls: 1 (start) + 8*2 (per failure) + 1 (success log) = 18 total.
+        """
+        unavailable_err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
+        stub = MagicMock()
+        stub.Upload.side_effect = [unavailable_err] * 8 + [MagicMock()]
+        request = MagicMock()
+
+        with patch.object(_plugin_mod, "current_app"):
+            with patch.object(_plugin_time, "sleep") as mock_sleep:
+                with patch.object(_plugin_time, "monotonic", side_effect=self._monotonic_seq()):
+                    _upload_with_retry(
+                        stub, request, self.AUTH_TOKEN,
+                        retry_timeout_seconds=9999, initial_wait_seconds=1,
+                    )
+
+        sleep_args = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_args == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 60.0, 60.0]
+        assert all(v <= 60.0 for v in sleep_args)

--- a/lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py
+++ b/lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py
@@ -281,8 +281,7 @@ class TestUploadWithRetry:
         """stub.Upload called 3 times when first two raise retriable UNAVAILABLE.
 
         monotonic() call pattern (deadline=9999):
-          [0] start; [1] elapsed1; [2] deadline1 check; [3] elapsed2; [4] deadline2 check;
-          [5] success log (attempt>0).
+          [0] start; [1] now (failure 1); [2] now (failure 2); [3] success log.
         """
         unavailable_err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
         stub = MagicMock()
@@ -323,26 +322,15 @@ class TestUploadWithRetry:
 
         monotonic() call pattern (deadline = start + 5 = 5):
           [0] start → deadline=5;
-          [1] elapsed (= 1.0, elapsed=1.0);
-          [2] deadline check → 2.0 < 5 → NOT past deadline yet.
-
-        We need the SECOND failure's deadline check to be >= 5. So we return
-        a sequence where after the second failure the deadline check value >= 5.
-        Concretely: [0, 1, 1, 6, 10] gives:
-          monotonic[0]=0 → deadline=5
-          monotonic[1]=1 → elapsed1=1
-          monotonic[2]=1 → 1 < 5, not expired → sleep → retry
-          monotonic[3]=6 → elapsed2=6
-          monotonic[4]=10 → 10 >= 5 → EXPIRED → raise
+          [1] now (failure 1): elapsed=1.0, 1.0 < 5 → not expired → sleep → retry
+          [2] now (failure 2): elapsed=6.0, 6.0 >= 5 → EXPIRED → raise
         """
         unavailable_err = make_rpc_error(grpc.StatusCode.UNAVAILABLE, "no healthy upstream")
         stub = MagicMock()
-        # Keep raising on every call so we can control exactly when timeout hits
         stub.Upload.side_effect = unavailable_err
         request = MagicMock()
 
-        # Let the first failure pass (not timed out) and the second fail with timeout.
-        monotonic_values = [0.0, 1.0, 1.0, 6.0, 10.0] + [10.0] * 5
+        monotonic_values = [0.0, 1.0, 6.0] + [10.0] * 5
 
         with patch.object(_plugin_mod, "current_app"):
             with patch.object(_plugin_time, "sleep"):

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(
             "aws_s3 = lemur.plugins.lemur_aws.plugin:S3DestinationPlugin",
             "aws_sns = lemur.plugins.lemur_aws.plugin:SNSNotificationPlugin",
             "coa_destination = cert_orchestration_adapter.plugin:AdapterDestinationPlugin",
+            "coa_destination_retrying = lemur.plugins.lemur_vault_dest.plugin:COADestinationPlugin",
             "coa_source = cert_orchestration_adapter.plugin:AdapterSourcePlugin",
             "email_notification = lemur.plugins.lemur_email.plugin:EmailNotificationPlugin",
             "slack_notification = lemur.plugins.lemur_slack.plugin:SlackNotificationPlugin",

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
             "aws_s3 = lemur.plugins.lemur_aws.plugin:S3DestinationPlugin",
             "aws_sns = lemur.plugins.lemur_aws.plugin:SNSNotificationPlugin",
             "coa_destination = cert_orchestration_adapter.plugin:AdapterDestinationPlugin",
-            "coa_destination_retrying = lemur.plugins.lemur_vault_dest.plugin:COADestinationPlugin",
+            "coa_destination_retry = lemur.plugins.lemur_vault_dest.plugin:COADestinationPlugin",
             "coa_source = cert_orchestration_adapter.plugin:AdapterSourcePlugin",
             "email_notification = lemur.plugins.lemur_email.plugin:EmailNotificationPlugin",
             "slack_notification = lemur.plugins.lemur_slack.plugin:SlackNotificationPlugin",


### PR DESCRIPTION
## Summary

- Adds a new Lemur destination plugin **`COADestinationPlugin`** (slug: `coa-destination-retry`) in `lemur/plugins/lemur_vault_dest/plugin.py`.
- Registers the new plugin entry point in `setup.py` as `coa_destination_retry`.
- The existing `AdapterDestinationPlugin` (`coa_destination`) and `VaultDestinationPlugin` (`vault_desination`) are **untouched** — strictly additive change.

## Motivation

During new datacenter bootstrap, the Cert Orchestration Adapter (COA) may not yet be deployed on the target cluster when Lemur first attempts to push a certificate. Without retry logic, Lemur fails immediately with a gRPC `UNAVAILABLE` / "no healthy upstream" error, requiring an operator to manually re-submit. This plugin retries until COA comes up.

## New plugin options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `retry_until_healthy` | bool | `false` | When `true`, retry on `UNAVAILABLE`/"no healthy upstream" gRPC errors with exponential backoff instead of failing immediately. |
| `retry_timeout_seconds` | int | `600` | Wall-clock deadline for the entire retry loop. Set to `0` to retry forever. Only used when `retry_until_healthy` is `true`. |
| `retry_initial_wait_seconds` | int | `5` | Initial wait before the first retry; doubles each attempt, capped at 60 s. Only used when `retry_until_healthy` is `true`. |

## Retry safety

- Only `UNAVAILABLE` errors whose detail string matches upstream-down patterns (`no healthy upstream`, `upstream connect error`, `connection refused`, `failed to connect`) are retried.
- Auth/permission errors (`UNAUTHENTICATED`, `PERMISSION_DENIED`, `INTERNAL`) and any other gRPC status codes **are never retried** — mis-configuration surfaces immediately.

## Observability

Each retry emits:
- **Metric** `lemur.plugins.coa.retry_attempt` (counter, tag `host:<endpoint>`)
- **Log** WARNING with fields: `attempt`, `wait_seconds`, `total_elapsed_seconds`, `endpoint`, `grpc_detail`

On success after retries:
- **Metric** `lemur.plugins.coa.retry_success` (counter, tag `host:<endpoint>`)
- **Log** INFO with fields: `attempt_count`, `endpoint`, `total_elapsed_seconds`

Metric emission failures are swallowed — a broken statsd provider never fails a cert upload.

## Tests

17 unit tests added in `lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py`:
- `_is_retriable_grpc_error`: 10 cases covering retriable/non-retriable status codes and detail strings
- `_upload_with_retry`: 7 cases covering first-attempt success, retry-then-succeed, non-retriable raise, timeout, and backoff progression

## Changes

| File | Change |
|------|--------|
| `lemur/plugins/lemur_vault_dest/plugin.py` | New `COADestinationPlugin` + retry helpers; `grpc` import guarded; `port` type `int` |
| `setup.py` | Entry point `coa_destination_retry` registered |
| `lemur/plugins/lemur_vault_dest/tests/test_coa_retry.py` | 17 unit tests (all passing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)