### PR TITLE
Auto-release on master merge

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,8 +14,6 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'Merge tag')"
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Get latest release and increment
       id: version

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,19 +17,17 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Get latest release tag and increment
+    - name: Get latest release and increment
       id: version
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        # Find the latest 1.0.0-dd.N tag
-        LATEST_TAG=$(git tag --list '1.0.0-dd.*' --sort=-version:refname | head -1)
+        LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
         if [ -z "$LATEST_TAG" ]; then
-          echo "No existing tags found, starting at 1.0.0-dd.1"
           NEW_TAG="1.0.0-dd.1"
         else
-          # Extract the N from 1.0.0-dd.N and increment
-          N=$(echo "$LATEST_TAG" | sed 's/1.0.0-dd.//')
-          NEXT=$((N + 1))
-          NEW_TAG="1.0.0-dd.${NEXT}"
+          N="${LATEST_TAG##*dd.}"
+          NEW_TAG="1.0.0-dd.$((N + 1))"
         fi
         echo "latest=$LATEST_TAG" >> "$GITHUB_OUTPUT"
         echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,17 +15,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Get latest release and increment
+    - name: Get latest release and compute next version
       id: version
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
-        if [ -z "$LATEST_TAG" ]; then
-          NEW_TAG="1.0.0-dd.1"
+        TODAY=$(date -u +%Y.%m.%d)
+        if [[ "$LATEST_TAG" == "$TODAY."* ]]; then
+          N="${LATEST_TAG##*.}"
+          NEW_TAG="${TODAY}.$((N + 1))"
         else
-          N="${LATEST_TAG##*dd.}"
-          NEW_TAG="1.0.0-dd.$((N + 1))"
+          NEW_TAG="${TODAY}.1"
         fi
         echo "latest=$LATEST_TAG" >> "$GITHUB_OUTPUT"
         echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,46 @@
+name: Auto-release on master merge
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip if the commit was a tag push (avoid double-triggering with manual releases)
+    if: "!startsWith(github.event.head_commit.message, 'Merge tag')"
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get latest release tag and increment
+      id: version
+      run: |
+        # Find the latest 1.0.0-dd.N tag
+        LATEST_TAG=$(git tag --list '1.0.0-dd.*' --sort=-version:refname | head -1)
+        if [ -z "$LATEST_TAG" ]; then
+          echo "No existing tags found, starting at 1.0.0-dd.1"
+          NEW_TAG="1.0.0-dd.1"
+        else
+          # Extract the N from 1.0.0-dd.N and increment
+          N=$(echo "$LATEST_TAG" | sed 's/1.0.0-dd.//')
+          NEXT=$((N + 1))
+          NEW_TAG="1.0.0-dd.${NEXT}"
+        fi
+        echo "latest=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+        echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Create tag and release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git tag ${{ steps.version.outputs.new_tag }}
+        git push origin ${{ steps.version.outputs.new_tag }}
+        gh release create ${{ steps.version.outputs.new_tag }} \
+          --title "${{ steps.version.outputs.new_tag }}" \
+          --generate-notes \
+          --notes-start-tag "${{ steps.version.outputs.latest }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,12 @@ cd lemur && lemur db migrate -m "description"
 
 ## Release Process
 
-Releases are automated. Merging to master triggers a GitHub Action that auto-increments the `1.0.0-dd.N` tag, creates a GitHub Release, and kicks off the GitLab CI image build. Conductor in k8s-resources picks up the new image automatically (staging every 30 min, prod/gov on weekday schedule).
+Releases are automated. Merging to master triggers a GitHub Action that creates a CalVer tag (`YYYY.MM.DD.N`), creates a GitHub Release with auto-generated notes, and kicks off the GitLab CI image build. Conductor in k8s-resources picks up the new image automatically (staging every 30 min, prod/gov on weekday schedule).
 
-Tag format: `1.0.0-dd.N`. Increment the trailing number only.
-
-For manual releases (e.g., changelog-only or upstream sync), you can still tag manually:
+For manual releases, you can still tag manually:
 ```bash
-git tag 1.0.0-dd.N && git push origin 1.0.0-dd.N
-gh release create 1.0.0-dd.N --title "1.0.0-dd.N" --generate-notes
+git tag 2026.04.24.1 && git push origin 2026.04.24.1
+gh release create 2026.04.24.1 --title "2026.04.24.1" --generate-notes
 ```
 
 ## Runbooks & References

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,42 +101,15 @@ cd lemur && lemur db migrate -m "description"
 
 ## Release Process
 
-Tag format: `1.0.0-dd.N`. Pushing a tag triggers GitLab CI to build and push prod images (regular + FIPS).
+Releases are automated. Merging to master triggers a GitHub Action that auto-increments the `1.0.0-dd.N` tag, creates a GitHub Release, and kicks off the GitLab CI image build. Conductor in k8s-resources picks up the new image automatically (staging every 30 min, prod/gov on weekday schedule).
 
-1. **Update `CHANGELOG.rst`** — add entry at the top (after the `Changelog` heading):
-   ```rst
-   1.0.0-dd.N - `YYYY-MM-DD`
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tag format: `1.0.0-dd.N`. Increment the trailing number only.
 
-   Features:
-   - Description (#PR)
-
-   Bug fixes:
-   - Description (#PR)
-
-   Security fixes:
-   - CVE description (#PR or Jira link)
-   ```
-   Omit empty sections. Commit to `master`.
-
-2. **Push the tag**:
-   ```bash
-   git tag 1.0.0-dd.N && git push origin 1.0.0-dd.N
-   ```
-
-3. **Create the GitHub Release**:
-   ```bash
-   gh release create 1.0.0-dd.N --title "1.0.0-dd.N" --notes "$(cat <<'EOF'
-   - Description (#PR)
-
-   **Full Changelog**: https://github.com/DataDog/lemur/compare/1.0.0-dd.PREV...1.0.0-dd.N
-   EOF
-   )"
-   ```
-
-4. **Deploy**: bump image tag in `chart/values.yaml` in k8s-resources and open a PR.
-
-Versioning: increment the trailing number only (`1.0.0-dd.(N+1)`).
+For manual releases (e.g., changelog-only or upstream sync), you can still tag manually:
+```bash
+git tag 1.0.0-dd.N && git push origin 1.0.0-dd.N
+gh release create 1.0.0-dd.N --title "1.0.0-dd.N" --generate-notes
+```
 
 ## Runbooks & References
 - Wiki: https://datadoghq.atlassian.net/wiki/spaces/NE/pages/2130608302/Lemur+Certificate+Orchestration


### PR DESCRIPTION
Every merge to master auto-increments the 1.0.0-dd.N tag and creates a GitHub Release with auto-generated notes. GitLab CI then builds the prod image with this semantic tag so Conductor deploys a meaningfully versioned image instead of opaque pipeline IDs.

This replaces the manual 7-step release process (update changelog, tag, create release, bump values.yaml, merge, wait). Now it's just: merge to master, everything else happens automatically.

Skips tag-merge commits to avoid double-triggering with manual releases.

RDNA-816