### PR TITLE
Fix auto-release tag creation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,20 +5,27 @@ on:
     branches: [master]
 
 permissions:
-  contents: write
+  id-token: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Skip if the commit was a tag push (avoid double-triggering with manual releases)
     if: "!startsWith(github.event.head_commit.message, 'Merge tag')"
     steps:
     - uses: actions/checkout@v4
 
+    - name: Get dd-octo-sts token
+      id: octo-sts
+      uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+      with:
+        scope: DataDog/lemur
+        policy: self.auto-release
+
     - name: Get latest release and compute next version
       id: version
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       run: |
         LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
         TODAY=$(date -u +%Y.%m.%d)
@@ -33,7 +40,7 @@ jobs:
 
     - name: Create release
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       run: |
         gh release create ${{ steps.version.outputs.new_tag }} \
           --target ${{ github.sha }} \

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,8 +19,8 @@ jobs:
       id: octo-sts
       uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
       with:
-        scope: DataDog/lemur
-        policy: self.auto-release
+        scope: DataDog
+        policy: lemur.github.auto-release.push
 
     - name: Get latest release and compute next version
       id: version

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,42 @@
+name: Auto-release on master merge
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip if the commit was a tag push (avoid double-triggering with manual releases)
+    if: "!startsWith(github.event.head_commit.message, 'Merge tag')"
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get latest release and compute next version
+      id: version
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
+        TODAY=$(date -u +%Y.%m.%d)
+        if [[ "$LATEST_TAG" == "$TODAY."* ]]; then
+          N="${LATEST_TAG##*.}"
+          NEW_TAG="${TODAY}.$((N + 1))"
+        else
+          NEW_TAG="${TODAY}.1"
+        fi
+        echo "latest=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+        echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Create release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create ${{ steps.version.outputs.new_tag }} \
+          --target ${{ github.sha }} \
+          --title "${{ steps.version.outputs.new_tag }}" \
+          --generate-notes \
+          --notes-start-tag "${{ steps.version.outputs.latest }}"


### PR DESCRIPTION
The org-level tag protection ruleset blocks git push of tags from GitHub Actions. Uses gh release create --target instead, which creates the tag server-side via the Releases API.

RDNA-816