### PR TITLE
Only build prod images from tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,7 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
+# Prod images are only built from tags.
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,8 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
-# build a prod-signed image on master commits and tags
+# Prod images are only built from tags (auto-release creates a CalVer tag
+# on every master merge, so master-commit builds are no longer needed).
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image
@@ -82,9 +83,6 @@ build-prod-image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_TAG: "$CI_COMMIT_TAG"
-    - if: $CI_COMMIT_BRANCH == "master" && $GBILITE_GITLAB_ACTION == null
-      variables:
-        IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
@@ -103,9 +101,6 @@ build-prod-image-fips:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_TAG: "$CI_COMMIT_TAG"
-    - if: $CI_COMMIT_BRANCH == "master" && $GBILITE_GITLAB_ACTION == null
-      variables:
-        IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,6 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
-# Prod images are only built from tags.
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,8 +72,6 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
-# Prod images are only built from tags (auto-release creates a CalVer tag
-# on every master merge, so master-commit builds are no longer needed).
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image


### PR DESCRIPTION
Auto-release creates a CalVer tag on every master merge, so the master-commit prod builds are redundant. They also cause artifact_reference_latest in k8s-resources to pick the pipeline-ID tagged image instead of the CalVer one.

RDNA-816