### PR TITLE
parallel regular/FIPS image builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,7 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
+# Prod images are only built from tags.
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,8 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
-# build a prod-signed image on master commits and tags
+# Prod images are only built from tags (auto-release creates a CalVer tag
+# on every master merge, so master-commit builds are no longer needed).
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image
@@ -82,9 +83,6 @@ build-prod-image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_TAG: "$CI_COMMIT_TAG"
-    - if: $CI_COMMIT_BRANCH == "master" && $GBILITE_GITLAB_ACTION == null
-      variables:
-        IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
@@ -103,9 +101,6 @@ build-prod-image-fips:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_TAG: "$CI_COMMIT_TAG"
-    - if: $CI_COMMIT_BRANCH == "master" && $GBILITE_GITLAB_ACTION == null
-      variables:
-        IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,6 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
-# Prod images are only built from tags.
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,7 @@ variables:
 stages:
   - test
   - build-stage-image
-  - build-stage-image-fips
   - build-prod-image
-  - build-prod-image-fips
   - gbilite
 
 test:
@@ -58,7 +56,7 @@ build-stage-image:
 
 build-stage-image-fips:
   image: $CURRENT_CI_IMAGE
-  stage: build-stage-image-fips
+  stage: build-stage-image
   when: on_success
   rules:
     - if: ($CI_COMMIT_TAG == null && $GBILITE_GITLAB_ACTION == null)
@@ -96,7 +94,7 @@ build-prod-image:
 
 build-prod-image-fips:
   image: $CURRENT_CI_IMAGE
-  stage: build-prod-image-fips
+  stage: build-prod-image
   when: on_success
   timeout: 2h
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,8 +72,6 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
-# Prod images are only built from tags (auto-release creates a CalVer tag
-# on every master merge, so master-commit builds are no longer needed).
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image


### PR DESCRIPTION
Run regular and FIPS image builds in the same stage so they execute in parallel. Saves ~4 min per pipeline.

RDNA-816