### PR TITLE
Add image labels for artifact_reference_latest resolution

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -34,7 +34,6 @@ docker buildx build \
   --build-arg BASE_IMAGE=$BASE_IMAGE \
   --build-arg FIPS_ENABLED=$FIPS_ENABLED \
   --build-arg GBILITE_ENV=$GBILITE_ENV \
-  --build-arg IMAGE_TAG=$IMAGE_TAG \
   --tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD \
   --metadata-file ${METADATA_FILE} \
   --push \

--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -33,6 +33,7 @@ docker buildx build \
   --build-arg CI_COMMIT_SHA=$CHECKOUT_REF \
   --build-arg BASE_IMAGE=$BASE_IMAGE \
   --build-arg FIPS_ENABLED=$FIPS_ENABLED \
+  --build-arg GBILITE_ENV=$GBILITE_ENV \
   --tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD \
   --metadata-file ${METADATA_FILE} \
   --push \

--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -34,6 +34,7 @@ docker buildx build \
   --build-arg BASE_IMAGE=$BASE_IMAGE \
   --build-arg FIPS_ENABLED=$FIPS_ENABLED \
   --build-arg GBILITE_ENV=$GBILITE_ENV \
+  --build-arg IMAGE_TAG=$IMAGE_TAG \
   --tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD \
   --metadata-file ${METADATA_FILE} \
   --push \

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -53,10 +53,15 @@ FROM $BASE_IMAGE
 ARG FIPS_ENABLED=false
 ARG CI_COMMIT_SHA
 ARG GBILITE_ENV=prod
+ARG IMAGE_TAG
 LABEL IS_FIPS=$FIPS_ENABLED
 LABEL git.repository="lemur"
 LABEL git.branch=$GBILITE_ENV
 LABEL git.commit=$CI_COMMIT_SHA
+LABEL org.opencontainers.image.source="https://github.com/DataDog/lemur"
+LABEL org.opencontainers.image.revision=$CI_COMMIT_SHA
+LABEL org.opencontainers.image.version=$IMAGE_TAG
+LABEL org.opencontainers.image.vendor="datadog"
 
 USER root
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -50,9 +50,13 @@ RUN /opt/venv/bin/python3 -m pip install --no-cache-dir --no-deps --force-reinst
 # Lemur Application
 FROM $BASE_IMAGE
 
-# FIPS mode
 ARG FIPS_ENABLED=false
+ARG CI_COMMIT_SHA
+ARG GBILITE_ENV=prod
 LABEL IS_FIPS=$FIPS_ENABLED
+LABEL git.repository="lemur"
+LABEL git.branch=$GBILITE_ENV
+LABEL git.commit=$CI_COMMIT_SHA
 
 USER root
 

--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -53,15 +53,10 @@ FROM $BASE_IMAGE
 ARG FIPS_ENABLED=false
 ARG CI_COMMIT_SHA
 ARG GBILITE_ENV=prod
-ARG IMAGE_TAG
 LABEL IS_FIPS=$FIPS_ENABLED
 LABEL git.repository="lemur"
 LABEL git.branch=$GBILITE_ENV
 LABEL git.commit=$CI_COMMIT_SHA
-LABEL org.opencontainers.image.source="https://github.com/DataDog/lemur"
-LABEL org.opencontainers.image.revision=$CI_COMMIT_SHA
-LABEL org.opencontainers.image.version=$IMAGE_TAG
-LABEL org.opencontainers.image.vendor="datadog"
 
 USER root
 


### PR DESCRIPTION
Overrides the base image's git.repository and git.branch labels with lemur-specific values so artifact_reference_latest in k8s-resources can correctly resolve lemur images. Without this, the SDM metadata API sees the GBI base image's metadata (git.repository=images, git.branch=master) and resolves the wrong image.

RDNA-816