### PR TITLE
build prod-signed images on master commits again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,7 @@ build-stage-image-fips:
   script:
     - CHECKOUT_REF=$CI_COMMIT_SHA GBILITE_ENV=staging GBILITE_IMAGE_TO_BUILD="lemur:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips" /bin/bash .campaigns/build_and_push_image.sh
 
+# build a prod-signed image on master commits and tags
 build-prod-image:
   image: $CURRENT_CI_IMAGE
   stage: build-prod-image
@@ -81,6 +82,9 @@ build-prod-image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_TAG: "$CI_COMMIT_TAG"
+    - if: $CI_COMMIT_BRANCH == "master" && $GBILITE_GITLAB_ACTION == null
+      variables:
+        IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
@@ -99,6 +103,9 @@ build-prod-image-fips:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_TAG: "$CI_COMMIT_TAG"
+    - if: $CI_COMMIT_BRANCH == "master" && $GBILITE_GITLAB_ACTION == null
+      variables:
+        IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   tags: ["arch:amd64"]
   variables:
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"


### PR DESCRIPTION
Reverts #266. We removed master-commit prod builds because the auto-release CalVer flow was supposed to cover that path, but auto-release is gone too now. Net result: nothing produces a new prod image on a master merge, so mutable-latest-prod is stuck at the last manually-tagged image (2026.04.24.4).

Bringing back the v{pipeline_id}-{short_sha} build on master so every merge produces a prod image and mutable-latest-prod stays current.