### PR TITLE
Bump COA to 0.1.35

### DIFF
--- a/requirements-dd-source.in
+++ b/requirements-dd-source.in
@@ -3,6 +3,6 @@
 #
 # To bump a version: update the URL here and rebuild the Docker image.
 
-https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.34-py3-none-any.whl
+https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.35-py3-none-any.whl
 # Must match version enforced in the above COA wheel's requires (dd-source BUILD.bazel)
 https://binaries.ddbuild.io/dd-source/python/dd_internal_authentication-1.9.0-py2.py3-none-any.whl


### PR DESCRIPTION
Picks up the get_certificates fix from DataDog/dd-source#426102: the COA plugin no longer swallows fetch errors and returns a partial cert list.

Lemur's sync_certificates treats absent certs as "removed from source" and unlinks destinations, which caused the destination flap reported in RDNA-946. After this bump, any fetch or parse failure in COA propagates so celery fails the sync_source task loudly instead of silently mis-removing destinations.

Depends on DataDog/dd-source#426102 landing first (which is what cuts the 0.1.35 wheel).