### PR TITLE
Skip me-south-1 in AWS source LB sync

### DIFF
--- a/lemur/plugins/lemur_aws/plugin.py
+++ b/lemur/plugins/lemur_aws/plugin.py
@@ -327,6 +327,8 @@ class AWSSourcePlugin(SourcePlugin):
             regions = "".join(regions.split()).split(",")
 
         for region in regions:
+            if region == "me-south-1":
+                continue  # AWS Bahrain offline since Apr 2026 missile strike on Batelco
             elbs = elb.get_all_elbs(account_number=account_number, region=region)
             current_app.logger.info(
                 {


### PR DESCRIPTION
AWS Bahrain has been physically impaired since the Apr 1 2026 missile strike on Batelco HQ (the AWS colocation host). Public endpoints in the region TCP-blackhole — DNS resolves but SYN packets get nowhere.

For the [michelada] AWS IAM source, that means a single elb.describe_load_balancers call against me-south-1 stalls for botocore's full retry budget (~20 minutes). The whole sync_source chain blocks behind it for hours, eventually hitting the 2h soft_time_limit and triggering the destination flap reported in RDNA-946.

AWS recommends migrating workloads out of me-south-1 with no ETA. Skip the region until it's restored.

Validation: confirmed via aws cli that elasticloadbalancing.me-south-1.amazonaws.com (and ec2/s3 endpoints) TCP-timeout while every other region returns in 3-5s. michelada has no LBs in me-south-1 (or any region except 7 ELBv2 in us-east-1).