### PR TITLE
Drop sync_chain_active Redis guard and complete_sync_chain task

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -505,15 +505,6 @@ def clean_source(source):
 
 
 @celery_app.task()
-def complete_sync_chain():
-    red.delete("sync_chain_active")
-    # Mark sync_all_sources as successful now that all sources have synced
-    function = f"{__name__}.sync_all_sources"
-    red.set(f"{function}.last_success", int(time.time()))
-    metrics.send(f"{function}.success", "counter", 1)
-
-
-@celery_app.task()
 def sync_all_sources():
     """
     This function will sync certificates from all sources. This function triggers one celery task per source.
@@ -534,25 +525,13 @@ def sync_all_sources():
         current_app.logger.debug(log_data)
         return
 
-    # Skip if a previous sync chain is still running
-    if red.get("sync_chain_active"):
-        log_data["message"] = "Skipping: previous sync chain is still running"
-        current_app.logger.warning(log_data)
-        return log_data
-
     sources = validate_sources("all")
-    # Source syncs are heavy, chain them sequentially so they don't flood the queue
-    from celery import chain
-    red.set("sync_chain_active", "1", ex=7200)  # cleared by complete_sync_chain at end of chain, 2h expiry is a safety net
-    tasks = []
     for source in sources:
         log_data["source"] = source.label
         current_app.logger.debug(log_data)
-        tasks.append(sync_source.si(source.label))
-    tasks.append(complete_sync_chain.si())
-    if tasks:
-        chain(*tasks).delay()
+        sync_source.delay(source.label)
 
+    metrics.send(f"{function}.success", "counter", 1)
     return log_data
 
 
@@ -595,12 +574,6 @@ def sync_source(source):
             "sync_source_timeout", "counter", 1, metric_tags={"source": source}
         )
         metrics.send("celery.timeout", "counter", 1, metric_tags={"function": function})
-        return
-    except Exception as e:
-        log_data["message"] = f"Error syncing source: {e}"
-        current_app.logger.error(log_data)
-        capture_exception()
-        metrics.send(f"{function}.failure", "counter", 1, metric_tags={"source": source})
         return
 
     log_data["message"] = "Done syncing source"


### PR DESCRIPTION
Reverts the bulk of #244 — sequential chaining via celery.chain, the sync_chain_active Redis flag, the complete_sync_chain task, and the catch-all 'except Exception' in sync_source. Brings sync_all_sources and sync_source back in line with upstream Netflix/lemur (parallel sync_source.delay() per source, only SoftTimeLimitExceeded caught).

Why this is safe to revert:

- The chain guard was added because [michelada] AWS IAM was hanging for 40+ hours holding a worker. The root cause turned out to be that AWS me-south-1 has been physically impaired since the Apr 2026 missile strike on Batelco HQ — endpoints in that region TCP-blackhole.
- #274 skips me-south-1 from the AWS source iteration, eliminating the hang at its source.
- DataDog/dd-source#426102 (COA 0.1.35) makes the COA plugin raise on partial fetches instead of swallowing exceptions, so any future fetch failure surfaces loudly rather than producing the destination flap.
- The 2h soft_time_limit (#269) bounds any remaining slow source.

With those three changes in place, the original 'a single source can hang for hours and block everything' justification no longer applies. Parallel dispatch is the upstream design and means a single slow source on one worker doesn't block downstream sources on other workers — better for things like the Vault Bootstrap recovery we observed today.

Depends on #274 landing first.