### PR TITLE
Bump COA wheel to 0.1.36 and add fabric-gateways as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*                            @DataDog/fabric-edge-ingress @DataDog/runtime-dna
+*                            @DataDog/fabric-edge-ingress @DataDog/fabric-gateways @DataDog/runtime-dna

--- a/requirements-dd-source.in
+++ b/requirements-dd-source.in
@@ -3,6 +3,6 @@
 #
 # To bump a version: update the URL here and rebuild the Docker image.
 
-https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.35-py3-none-any.whl
+https://binaries.ddbuild.io/dd-source/python/cert_orchestration_adapter-0.1.36-py3-none-any.whl
 # Must match version enforced in the above COA wheel's requires (dd-source BUILD.bazel)
 https://binaries.ddbuild.io/dd-source/python/dd_internal_authentication-1.9.0-py2.py3-none-any.whl


### PR DESCRIPTION
Picks up the latest cert_orchestration_adapter wheel build (OOM crash fix). Also adds fabric-gateways alongside the existing default owners so they can review COA integration changes.