### PR TITLE
Add fabric-gateways as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*                            @DataDog/fabric-edge-ingress @DataDog/runtime-dna
+*                            @DataDog/fabric-edge-ingress @DataDog/fabric-gateways @DataDog/runtime-dna


### PR DESCRIPTION
Adds fabric-gateways alongside the existing default owners so they can review changes that touch the COA integration.