### PR TITLE
Only re-tag mutable-latest-prod from master-commit builds

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -42,10 +42,7 @@ docker buildx build \
   .
 ddsign sign registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD --docker-metadata-file ${METADATA_FILE}
 
-# Tag as mutable-latest only from master-commit builds. Tag builds may rebuild
-# an older release (e.g. when a pipeline re-runs an existing tag for a base
-# image refresh) and must not regress the mutable-latest pointer to that older
-# code.
+# Tag as mutable-latest only from master-commit builds.
 if [[ "$CI_COMMIT_BRANCH" == "master" && $GBILITE_ENV == "prod" && $FIPS_ENABLED == "false" ]]; then
   crane tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD mutable-latest-prod
 elif [[ "$CI_COMMIT_BRANCH" == "master" && $GBILITE_ENV == "prod" && $FIPS_ENABLED == "true" ]]; then

--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -42,10 +42,13 @@ docker buildx build \
   .
 ddsign sign registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD --docker-metadata-file ${METADATA_FILE}
 
-# Tag as mutable-latest for Conductor image resolution.
-if [[ $GBILITE_ENV == "prod" && $FIPS_ENABLED == "false" ]]; then
+# Tag as mutable-latest only from master-commit builds. Tag builds may rebuild
+# an older release (e.g. when a pipeline re-runs an existing tag for a base
+# image refresh) and must not regress the mutable-latest pointer to that older
+# code.
+if [[ "$CI_COMMIT_BRANCH" == "master" && $GBILITE_ENV == "prod" && $FIPS_ENABLED == "false" ]]; then
   crane tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD mutable-latest-prod
-elif [[ $GBILITE_ENV == "prod" && $FIPS_ENABLED == "true" ]]; then
+elif [[ "$CI_COMMIT_BRANCH" == "master" && $GBILITE_ENV == "prod" && $FIPS_ENABLED == "true" ]]; then
   crane tag registry.ddbuild.io/$GBILITE_IMAGE_TO_BUILD mutable-latest-prod-fips
 fi
 


### PR DESCRIPTION
Tag builds (e.g. when a pipeline re-runs an existing release tag for a base image refresh) currently overwrite the `mutable-latest-prod` pointer with the tag's older commit, regressing prod to that older code. Guard the re-tag step on `CI_COMMIT_BRANCH == master` so only master-commit builds advance the pointer.

Concrete instance: pipeline #111137882 ran on 2026-05-03 with `source: api`, built tag `1.0.0-dd.50` (commit `18c337b9`, April 29 — older than master HEAD `c92c5d78`), and overwrote mutable-latest-prod to point at that older image, which the next scheduled deploy rolled out.