### PR TITLE
Add jitter to ACME pending cert dispatch

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -9,6 +9,7 @@ command: celery -A lemur.common.celery worker --loglevel=info -l DEBUG -B
 """
 
 import copy
+import random
 import sys
 import time
 from celery import Celery
@@ -395,7 +396,8 @@ def fetch_all_pending_acme_certs():
                 log_data["cert_name"] = cert.name
                 log_data["cert_id"] = cert.id
                 current_app.logger.debug(log_data)
-                fetch_acme_cert.delay(cert.id)
+                jitter = random.randint(0, current_app.config.get("ACME_JITTER_MAX_SECONDS", 21600))
+                fetch_acme_cert.apply_async(args=[cert.id], countdown=jitter)
 
     metrics.send(f"{function}.success", "counter", 1)
     return log_data


### PR DESCRIPTION
## Summary

- Adds `random.randint(0, ACME_JITTER_MAX_SECONDS)` countdown to `fetch_acme_cert` dispatch in `fetch_all_pending_acme_certs`
- Default window: 6 hours (21600s). Configurable via `ACME_JITTER_MAX_SECONDS`; set to `0` to disable
- Prevents thundering herd when many certs enter their renewal window on the same day and all hit the Let's Encrypt API simultaneously

## Why

`fetch_all_pending_acme_certs` runs every minute and dispatches a `fetch_acme_cert` Celery task per pending cert. Without jitter, all certs pending on a given day are dispatched simultaneously, hitting the LE ACME API and DNS validation in one burst. This risks the 5 failed validations/hostname/hour LE rate limit.

## Deployment note

The `fetch_all_pending_acme_certs` Celery task is currently disabled in production. A companion k8s-resources PR enables it. **Deploy this PR first** (so workers have the jitter code), then merge the k8s-resources PR to activate the schedule.

## Test plan

- [ ] Verify `ACME_JITTER_MAX_SECONDS=0` restores original `fetch_acme_cert.delay()` behavior (no countdown)
- [ ] In staging: enable task, confirm pending ACME certs are dispatched with spread countdowns visible in Celery logs
- [ ] Confirm no regression in `fetch_acme_cert` success rate

**Workspace:** `local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)