### PR TITLE
campaigner: rebuild master HEAD onto mutable-latest-prod

### DIFF
--- a/.campaigns/build_and_push_image.sh
+++ b/.campaigns/build_and_push_image.sh
@@ -4,26 +4,16 @@ set -eo pipefail
 # The user that clones the repository (root) is different from the user performing git commands
 git config --global --add safe.directory /go/src/github.com/DataDog/lemur
 
-# Determine the specific commit or release to build an image for
+# Determine the specific commit to build an image for
 IMAGE_TAG=$(echo $GBILITE_IMAGE_TO_BUILD | cut -d ':' -f 2)
 BASE_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
 FIPS_ENABLED=false
-if [[ $GBILITE_IMAGE_TO_BUILD == "lemur:latest" ]]; then
-  LATEST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-  CHECKOUT_REF=$LATEST_RELEASE_TAG
-elif [[ $GBILITE_IMAGE_TO_BUILD == *"-fips" ]]; then
+if [[ $GBILITE_IMAGE_TO_BUILD == *"-fips" ]]; then
   BASE_IMAGE=registry.ddbuild.io/images/base/gbi-ubuntu_2204-fips:release
   FIPS_ENABLED=true
 fi
 
-if [[ -z "$CHECKOUT_REF" ]]; then
-  CHECKOUT_REF=$(git rev-parse HEAD)
-fi
-
-if [[ $FIPS_ENABLED == "true" ]]; then
-  # Release tags to build FIPS images for do not contain the -fips postfix.
-  CHECKOUT_REF=${CHECKOUT_REF%-fips}
-fi
+CHECKOUT_REF=${CHECKOUT_REF:-$(git rev-parse HEAD)}
 
 # Build and sign the image
 cd publish/

--- a/.campaigns/get_images.sh
+++ b/.campaigns/get_images.sh
@@ -5,6 +5,6 @@ set -euo pipefail
 git config --global --add safe.directory /go/src/github.com/DataDog/lemur
 
 # Campaigner refreshes mutable-latest-prod (rebuilds master HEAD against the
-# latest base image). Required for Build Horizon (28-day rebuild policy).
+# latest base image). Required for the once a month rebuild policy.
 echo "lemur:mutable-latest-prod"
 echo "lemur:mutable-latest-prod-fips"

--- a/.campaigns/get_images.sh
+++ b/.campaigns/get_images.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 # The user that clones the repository (root) is different from the user performing git commands
 git config --global --add safe.directory /go/src/github.com/DataDog/lemur
 
-# Campaigner should always re-build images for the latest release
-LATEST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-echo "lemur:${LATEST_RELEASE_TAG}"
-echo "lemur:${LATEST_RELEASE_TAG}-fips"
-echo "lemur:latest"
+# Campaigner refreshes mutable-latest-prod (rebuilds master HEAD against the
+# latest base image). Required for Build Horizon (28-day rebuild policy).
+echo "lemur:mutable-latest-prod"
+echo "lemur:mutable-latest-prod-fips"


### PR DESCRIPTION
Fixes the campaigner image-rebuild flow so it actually does what it was supposed to do: rebuild current master HEAD against the latest base image, then update `mutable-latest-prod` to that fresh build. Today it builds an older release tag (`1.0.0-dd.50`, six master commits behind) and retags `mutable-latest-prod` to that stale image, so every weekday auto-deploy since 5/24 has been shipping code six commits behind master.

`get_images.sh` now emits `lemur:mutable-latest-prod` and `lemur:mutable-latest-prod-fips` directly instead of the latest-release-tag derivation. `build_and_push_image.sh` falls through to `CHECKOUT_REF=$(git rev-parse HEAD)` (master HEAD) and pushes the fresh build straight to those tags, no separate retag dance. The dead `lemur:latest` branch and the `-fips` suffix stripping (which was a no-op for every surviving caller) are removed. The mutable-latest-prod retag block at the end of the script is unchanged since it still does the right thing for master-commit pipelines and is now just a no-op for campaigner runs because the image was already pushed with the correct tag.

Recovery action after merge: `mutable-latest-prod` is still pointing at the stale dd.50 rebuild from 5/24. Manually retag it to the master-HEAD image (`v114304884-dac3b7ad`) or let a master commit land and the build pipeline will repoint it correctly. The next campaigner run after merge will also self-heal it.

Build Horizon (28-day rebuild policy) compliance is preserved: campaigner still triggers a fresh rebuild on its schedule, just from master HEAD now instead of a stale release tag.