### PR TITLE
strip apostrophes from CA organization name reads

### DIFF
--- a/lemur/common/defaults.py
+++ b/lemur/common/defaults.py
@@ -105,7 +105,7 @@ def organization(cert):
         if not o:
             return None
 
-        return o[0].value.strip()
+        return o[0].value.strip().replace("'", "")
     except Exception as e:
         capture_exception()
         current_app.logger.error("Unable to get organization! {0}".format(e))

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -123,6 +123,8 @@ def parse_ca_vendor(chain):
         return "DigiCert"
     elif "Sectigo" in org_name:
         return "Sectigo"
+    elif "Let's Encrypt" in org_name or "Lets Encrypt" in org_name:
+        return "LetsEncrypt"
     return re.sub(r"[^A-Za-z0-9]", "", org_name)
 
 

--- a/lemur/plugins/lemur_azure/plugin.py
+++ b/lemur/plugins/lemur_azure/plugin.py
@@ -10,6 +10,8 @@
 .. moduleauthor:: sirferl
 """
 
+import re
+
 from flask import current_app
 from sentry_sdk import capture_exception
 from azure.keyvault.certificates import CertificateClient, CertificatePolicy
@@ -121,7 +123,7 @@ def parse_ca_vendor(chain):
         return "DigiCert"
     elif "Sectigo" in org_name:
         return "Sectigo"
-    return org_name.replace(" ", "").strip()
+    return re.sub(r"[^A-Za-z0-9]", "", org_name)
 
 
 def policy_from_appgw(network_client, appgw):


### PR DESCRIPTION
## Summary

- `defaults.organization()` now strips apostrophes at read time so all consumers get a clean string without needing to special-case individual CAs (e.g. `Let's Encrypt` → `Lets Encrypt`)
- `lemur_azure/plugin.py` `parse_ca_vendor` fallback upgraded from `replace(" ", "")` to `re.sub(r"[^A-Za-z0-9]", "")` for consistency — strips all non-alphanumeric chars, not just spaces


Also fix for tests to improve reliability on a cold start. 
**Workspace:** `local`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>