### PR TITLE
strip leaked local paths from pip-compile output

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,60 +6,60 @@
 #
 acme==5.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 alembic==1.14.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-migrate
 alembic-autogenerate-enums==0.1.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 amqp==5.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   kombu
 aniso8601==10.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-restful
 annotated-types==0.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic
 anyio==4.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cloudflare
     #   httpx
 arrow==1.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 async-timeout==5.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   redis
 asyncpool==1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 attrs==26.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   referencing
 aws-sam-translator==1.108.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 aws-xray-sdk==2.15.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 azure-common==1.1.28
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-mgmt-cdn
     #   azure-mgmt-subscription
 azure-core==1.39.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-identity
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
@@ -67,100 +67,100 @@ azure-core==1.39.0
     #   azure-mgmt-core
     #   msrest
 azure-identity==1.25.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-keyvault==4.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-keyvault-certificates==4.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault
 azure-keyvault-keys==4.11.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault
 azure-keyvault-secrets==4.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault
 azure-mgmt-cdn==13.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-mgmt-core==1.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 azure-mgmt-network==30.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-mgmt-subscription==3.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 backports-tarfile==1.2.0
     # via jaraco-context
 bandit==1.9.4
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 bcrypt==5.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-bcrypt
     #   paramiko
 billiard==4.2.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 black==26.3.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 blinker==1.9.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask
     #   flask-mail
     #   flask-principal
 boto3==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-sam-translator
     #   moto
 botocore==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
 celery[redis]==5.6.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 cert-manager==3.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 certbot==5.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 certifi==2026.2.25
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   httpcore
     #   httpx
     #   msrest
     #   requests
     #   sentry-sdk
 certsrv[ntlm]==2.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 cffi==2.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cryptography
     #   pynacl
 cfgv==3.5.0
     # via pre-commit
 cfn-lint==1.47.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 charset-normalizer==3.4.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   requests
 click==8.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   celery
     #   click-didyoumean
@@ -169,31 +169,31 @@ click==8.3.1
     #   flask
 click-didyoumean==0.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 click-plugins==1.1.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 cloudflare==4.3.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 configargparse==1.7.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 configobj==5.0.9
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 coverage==7.13.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 cryptography==43.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-dev.in
     #   acme
     #   azure-identity
@@ -215,47 +215,47 @@ cryptography==43.0.1
     #   types-redis
 deprecated==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   limits
 distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
     #   cloudflare
 dnspython==2.6.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 dnspython3==1.12.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 docker==7.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 docutils==0.22.4
     # via readme-renderer
 dyn==1.8.6
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 ecdsa==0.19.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
     #   python-jose
     #   sshpubkeys
 exceptiongroup==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   anyio
     #   celery
     #   pytest
 factory-boy==3.3.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 faker==40.11.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   factory-boy
 fakeredis==2.34.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 filelock==3.25.2
     # via
     #   python-discovery
@@ -268,7 +268,7 @@ flake8-pyproject==1.2.4
     # via -r requirements-dev.in
 flask==2.3.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-bcrypt
     #   flask-cors
     #   flask-limiter
@@ -280,63 +280,63 @@ flask==2.3.3
     #   flask-sqlalchemy
     #   pytest-flask
 flask-bcrypt==1.0.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-cors==6.0.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-limiter==4.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-mail==0.10.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-migrate==2.7.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-principal==0.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-replicated==2.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-restful==0.3.10
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-script==2.0.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-sqlalchemy==2.5.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-migrate
 freezegun==1.5.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 future==1.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 google-api-core[grpc]==2.30.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-auth==2.49.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-cloud-compute==1.46.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 google-cloud-private-ca==1.17.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 googleapis-common-protos[grpc]==1.73.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
 graphql-core==3.2.8
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 grpc-google-iam-v1==0.14.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-cloud-private-ca
 grpcio==1.78.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -345,52 +345,52 @@ grpcio==1.78.0
     #   grpcio-status
 grpcio-status==1.78.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
 gunicorn==25.1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 h11==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   httpcore
 httpcore==1.0.9
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   httpx
 httpx==0.28.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cloudflare
 hvac==2.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 id==1.6.1
     # via twine
 identify==2.6.18
     # via pre-commit
 idna==3.11
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   anyio
     #   httpx
     #   requests
 importlib-metadata==8.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   keyring
 inflection==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 iniconfig==2.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest
 invoke==2.2.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-dev.in
     #   paramiko
 isodate==0.7.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
@@ -399,7 +399,7 @@ isodate==0.7.2
     #   msrest
 itsdangerous==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask
 jaraco-classes==3.4.0
     # via keyring
@@ -409,137 +409,137 @@ jaraco-functools==4.4.0
     # via keyring
 javaobj-py3==0.4.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pyjks
 jinja2==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask
     #   moto
 jmespath==1.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   boto3
     #   botocore
 josepy==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   acme
     #   certbot
 jsondiff==2.2.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 jsonpatch==1.33
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 jsonpointer==3.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonpatch
 jsonschema==4.24.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-sam-translator
     #   openapi-schema-validator
     #   openapi-spec-validator
 jsonschema-path==0.4.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-spec-validator
 jsonschema-specifications==2025.9.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   openapi-schema-validator
 keyring==25.7.0
     # via twine
 kombu[redis]==5.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 lazy-object-proxy==1.12.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-spec-validator
 librt==0.8.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   mypy
 limits==5.8.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-limiter
 lockfile==0.12.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 logmatic-python==0.1.7
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 mako==1.3.10
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   alembic
 markdown-it-py==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   rich
 markupsafe==2.1.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jinja2
     #   mako
     #   werkzeug
 marshmallow==2.21.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 mccabe==0.7.0
     # via flake8
 mdurl==0.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   markdown-it-py
 more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
 moto[all]==4.2.14
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 mpmath==1.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   sympy
 msal==1.35.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-identity
     #   msal-extensions
 msal-extensions==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-identity
 msrest==0.7.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-mgmt-subscription
 multipart==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 mypy==1.19.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 mypy-extensions==1.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   mypy
 ndg-httpsclient==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 networkx==3.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 nh3==0.3.3
     # via readme-renderer
@@ -548,26 +548,26 @@ nodeenv==1.10.0
     #   -r requirements-dev.in
     #   pre-commit
 nose==1.3.7
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 oauthlib==3.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   requests-oauthlib
 openapi-schema-validator==0.8.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-spec-validator
 openapi-spec-validator==0.8.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 ordered-set==4.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-limiter
 packaging==26.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   gunicorn
     #   kombu
@@ -575,47 +575,47 @@ packaging==26.0
     #   pytest
     #   twine
 paramiko==4.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 parsedatetime==2.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 pathable==0.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema-path
 pathspec==1.0.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   mypy
 pem==23.1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 platformdirs==4.9.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   python-discovery
     #   virtualenv
 pluggy==1.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest
 pre-commit==4.5.1
     # via -r requirements-dev.in
 prompt-toolkit==3.0.52
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   click-repl
 proto-plus==1.27.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
 protobuf==6.33.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -624,14 +624,14 @@ protobuf==6.33.6
     #   grpcio-status
     #   proto-plus
 psycopg2==2.9.11
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 py-partiql-parser==0.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 pyasn1==0.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   ndg-httpsclient
     #   pyasn1-modules
     #   pyjks
@@ -640,7 +640,7 @@ pyasn1==0.6.3
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-auth
     #   pyjks
     #   python-ldap
@@ -648,15 +648,15 @@ pycodestyle==2.14.0
     # via flake8
 pycparser==3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pyjks
 pydantic==2.12.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-sam-translator
     #   cloudflare
     #   openapi-schema-validator
@@ -664,63 +664,63 @@ pydantic==2.12.5
     #   pydantic-settings
 pydantic-core==2.41.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic
 pydantic-settings==2.13.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-schema-validator
     #   openapi-spec-validator
 pyflakes==3.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flake8
 pygments==2.19.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest
     #   readme-renderer
     #   rich
 pyjks==20.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 pyjwt[crypto]==2.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   msal
 pynacl==1.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   acme
     #   ndg-httpsclient
 pyparsing==3.3.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 pyrfc3339==2.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   acme
     #   certbot
 pyspnego==0.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   requests-ntlm
 pytest==9.0.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest-flask
     #   pytest-mock
 pytest-flask==1.3.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 pytest-mock==3.15.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   arrow
     #   botocore
     #   celery
@@ -730,29 +730,29 @@ python-discovery==1.2.0
     # via virtualenv
 python-dotenv==1.2.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic-settings
 python-jose[cryptography]==3.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 python-json-logger==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   logmatic-python
 python-ldap==3.4.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 pytokens==0.4.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
 pytz==2026.1.post1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-restful
 pyyaml==6.0.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   bandit
     #   cfn-lint
     #   jsondiff
@@ -764,23 +764,23 @@ readme-renderer==44.0
     # via twine
 redis==6.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   fakeredis
     #   kombu
 referencing==0.37.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
     #   openapi-schema-validator
 regex==2026.2.28
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 requests==2.32.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   acme
     #   azure-core
     #   cert-manager
@@ -798,97 +798,97 @@ requests==2.32.5
     #   responses
     #   twine
 requests-mock==1.12.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 requests-ntlm==1.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certsrv
 requests-oauthlib==2.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   msrest
 requests-toolbelt==1.0.0
     # via twine
 responses==0.26.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 retrying==1.4.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 rfc3339-validator==0.1.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-schema-validator
 rfc3986==2.0.0
     # via twine
 rich==14.3.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   bandit
     #   twine
 rpds-py==0.30.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   referencing
 rsa==4.9.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   python-jose
 s3transfer==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   boto3
 sentry-sdk==2.55.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 simplejson==3.20.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 six==1.17.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   ecdsa
     #   flask-restful
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   anyio
     #   cloudflare
 sortedcontainers==2.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   fakeredis
 sqlalchemy==1.3.24
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   alembic
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 sshpubkeys==3.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 stevedore==5.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   bandit
 sympy==1.14.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 tabulate==0.10.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 toml==0.10.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cert-manager
 tomli==2.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   flake8-pyproject
     #   mypy
@@ -897,41 +897,41 @@ twine==6.2.0
     # via -r requirements-dev.in
 twofish==0.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pyjks
 types-cffi==2.0.0.20260316
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   types-pyopenssl
 types-deprecated==1.3.1.20260130
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-paramiko==4.0.0.20260322
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-protobuf==6.32.1.20260221
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-pyopenssl==24.1.0.20240722
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   types-redis
 types-pyrfc3339==2.0.1.20250825
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-pytz==2026.1.1.20260304
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-redis==4.6.0.20241004
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-requests==2.32.4.20260107
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-setuptools==82.0.0.20260210
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   types-cffi
 types-six==1.17.0.20251009
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-tabulate==0.10.0.20260308
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 typing-extensions==4.15.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   alembic
     #   anyio
     #   aws-sam-translator
@@ -959,21 +959,21 @@ typing-extensions==4.15.0
     #   virtualenv
 typing-inspection==0.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic
     #   pydantic-settings
 tzdata==2025.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   arrow
     #   kombu
 tzlocal==5.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 urllib3==2.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   botocore
     #   docker
     #   id
@@ -983,10 +983,10 @@ urllib3==2.6.3
     #   twine
     #   types-requests
 validators==0.35.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 vine==5.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   amqp
     #   celery
     #   kombu
@@ -994,27 +994,27 @@ virtualenv==21.2.0
     # via pre-commit
 wcwidth==0.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   prompt-toolkit
 werkzeug==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask
     #   flask-cors
     #   moto
     #   pytest-flask
 wrapt==2.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-xray-sdk
     #   deprecated
 xmltodict==1.0.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 zipp==3.23.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,65 +6,65 @@
 #
 acme==5.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   certbot
 alabaster==1.0.0
     # via sphinx
 alembic==1.14.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-migrate
 alembic-autogenerate-enums==0.1.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 amqp==5.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   kombu
 aniso8601==10.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-restful
 annotated-types==0.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic
 anyio==4.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cloudflare
     #   httpx
 arrow==1.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 async-timeout==5.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   redis
 asyncpool==1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 attrs==26.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   referencing
 aws-sam-translator==1.108.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 aws-xray-sdk==2.15.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 azure-common==1.1.28
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-mgmt-cdn
     #   azure-mgmt-subscription
 azure-core==1.39.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-identity
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
@@ -72,63 +72,63 @@ azure-core==1.39.0
     #   azure-mgmt-core
     #   msrest
 azure-identity==1.25.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-keyvault==4.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-keyvault-certificates==4.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault
 azure-keyvault-keys==4.11.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault
 azure-keyvault-secrets==4.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault
 azure-mgmt-cdn==13.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-mgmt-core==1.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 azure-mgmt-network==30.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 azure-mgmt-subscription==3.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 babel==2.18.0
     # via sphinx
 bandit==1.9.4
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 bcrypt==5.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-bcrypt
     #   paramiko
 billiard==4.2.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 black==26.3.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 blinker==1.9.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask
     #   flask-mail
     #   flask-principal
 boto3==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   aws-sam-translator
     #   moto
 botocore==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   aws-xray-sdk
     #   boto3
@@ -136,17 +136,17 @@ botocore==1.42.73
     #   s3transfer
 celery[redis]==5.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 cert-manager==3.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 certbot==5.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 certifi==2026.2.25
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   httpcore
     #   httpx
     #   msrest
@@ -154,24 +154,24 @@ certifi==2026.2.25
     #   sentry-sdk
 certsrv[ntlm]==2.1.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 cffi==2.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cryptography
     #   pynacl
 cfn-lint==1.47.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 charset-normalizer==3.4.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   requests
 click==8.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   celery
     #   click-didyoumean
@@ -180,33 +180,33 @@ click==8.3.1
     #   flask
 click-didyoumean==0.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 click-plugins==1.1.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 cloudflare==4.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 configargparse==1.7.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 configobj==5.0.9
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 coverage==7.13.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 cryptography==43.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   acme
     #   azure-identity
@@ -228,24 +228,24 @@ cryptography==43.0.1
     #   types-redis
 deprecated==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   limits
 distro==1.9.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
     #   cloudflare
 dnspython==2.6.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 dnspython3==1.12.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 docker==7.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 docutils==0.21.2
     # via
@@ -254,31 +254,31 @@ docutils==0.21.2
     #   sphinx-rtd-theme
 dyn==1.8.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 ecdsa==0.19.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
     #   python-jose
     #   sshpubkeys
 exceptiongroup==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   anyio
     #   celery
     #   pytest
 factory-boy==3.3.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 faker==40.11.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   factory-boy
 fakeredis==2.34.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask==2.3.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   flask-bcrypt
     #   flask-cors
@@ -292,79 +292,79 @@ flask==2.3.3
     #   pytest-flask
 flask-bcrypt==1.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-cors==6.0.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-limiter==4.1.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-mail==0.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-migrate==2.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-principal==0.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-replicated==2.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-restful==0.3.10
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 flask-script==2.0.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 flask-sqlalchemy==2.5.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   flask-migrate
 freezegun==1.5.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 future==1.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 google-api-core[grpc]==2.30.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-auth==2.49.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-cloud-compute==1.46.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 google-cloud-private-ca==1.17.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 googleapis-common-protos[grpc]==1.73.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
 graphql-core==3.2.8
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 grpc-google-iam-v1==0.14.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-cloud-private-ca
 grpcio==1.78.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -373,53 +373,53 @@ grpcio==1.78.0
     #   grpcio-status
 grpcio-status==1.78.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
 gunicorn==25.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 h11==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   httpcore
 httpcore==1.0.9
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   httpx
 httpx==0.28.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cloudflare
 hvac==2.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 idna==3.11
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   anyio
     #   httpx
     #   requests
 imagesize==2.0.0
     # via sphinx
 importlib-metadata==8.5.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 inflection==0.5.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 iniconfig==2.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest
 invoke==2.2.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   paramiko
 isodate==0.7.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
@@ -428,163 +428,163 @@ isodate==0.7.2
     #   msrest
 itsdangerous==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   flask
 javaobj-py3==0.4.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pyjks
 jinja2==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask
     #   moto
     #   sphinx
 jmespath==1.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   boto3
     #   botocore
 josepy==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   acme
     #   certbot
 jsondiff==2.2.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 jsonpatch==1.33
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 jsonpointer==3.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonpatch
 jsonschema==4.24.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-sam-translator
     #   openapi-schema-validator
     #   openapi-spec-validator
 jsonschema-path==0.4.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-spec-validator
 jsonschema-specifications==2025.9.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   openapi-schema-validator
 kombu[redis]==5.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 lazy-object-proxy==1.12.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-spec-validator
 librt==0.8.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   mypy
 limits==5.8.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-limiter
 lockfile==0.12.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 logmatic-python==0.1.7
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 mako==1.3.10
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   alembic
 markdown-it-py==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   rich
 markupsafe==2.1.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jinja2
     #   mako
     #   werkzeug
 marshmallow==2.21.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 mdurl==0.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   markdown-it-py
 moto[all]==4.2.14
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 mpmath==1.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   sympy
 msal==1.35.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-identity
     #   msal-extensions
 msal-extensions==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-identity
 msrest==0.7.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   azure-mgmt-subscription
 multipart==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 mypy==1.19.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 mypy-extensions==1.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   mypy
 ndg-httpsclient==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 networkx==3.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 nose==1.3.7
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 oauthlib==3.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   requests-oauthlib
 openapi-schema-validator==0.8.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-spec-validator
 openapi-spec-validator==0.8.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 ordered-set==4.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-limiter
 packaging==26.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   gunicorn
     #   kombu
@@ -593,46 +593,46 @@ packaging==26.0
     #   sphinx
 paramiko==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 parsedatetime==2.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certbot
 pathable==0.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema-path
 pathspec==1.0.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   mypy
 pem==23.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 platformdirs==4.9.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
 pluggy==1.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest
 prompt-toolkit==3.0.52
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   click-repl
 proto-plus==1.27.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
 protobuf==6.33.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -641,14 +641,14 @@ protobuf==6.33.6
     #   grpcio-status
     #   proto-plus
 psycopg2==2.9.11
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 py-partiql-parser==0.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 pyasn1==0.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   ndg-httpsclient
     #   pyasn1-modules
     #   pyjks
@@ -656,20 +656,20 @@ pyasn1==0.6.3
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   google-auth
     #   pyjks
 pycparser==3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pyjks
 pydantic==2.12.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-sam-translator
     #   cloudflare
     #   openapi-schema-validator
@@ -677,65 +677,65 @@ pydantic==2.12.5
     #   pydantic-settings
 pydantic-core==2.41.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic
 pydantic-settings==2.13.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-schema-validator
     #   openapi-spec-validator
 pyflakes==3.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 pygments==2.19.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest
     #   rich
     #   sphinx
 pyjks==20.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 pyjwt[crypto]==2.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   msal
 pynacl==1.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   acme
     #   ndg-httpsclient
 pyparsing==3.3.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 pyrfc3339==2.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   acme
     #   certbot
 pyspnego==0.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   requests-ntlm
 pytest==9.0.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pytest-flask
     #   pytest-mock
 pytest-flask==1.3.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 pytest-mock==3.15.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   arrow
     #   botocore
     #   celery
@@ -743,28 +743,28 @@ python-dateutil==2.9.0.post0
     #   moto
 python-dotenv==1.2.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic-settings
 python-jose[cryptography]==3.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 python-json-logger==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   logmatic-python
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 pytokens==0.4.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
 pytz==2026.1.post1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   flask-restful
 pyyaml==6.0.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   bandit
     #   cfn-lint
     #   jsondiff
@@ -773,24 +773,24 @@ pyyaml==6.0.3
     #   responses
 redis==6.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   fakeredis
     #   kombu
 referencing==0.37.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
     #   openapi-schema-validator
 regex==2026.2.28
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 requests==2.32.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   acme
     #   azure-core
     #   cert-manager
@@ -807,67 +807,67 @@ requests==2.32.5
     #   responses
     #   sphinx
 requests-mock==1.12.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 requests-ntlm==1.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   certsrv
 requests-oauthlib==2.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   msrest
 responses==0.26.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 retrying==1.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 rfc3339-validator==0.1.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   openapi-schema-validator
 rich==14.3.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   bandit
 rpds-py==0.30.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   jsonschema
     #   referencing
 rsa==4.9.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   python-jose
 s3transfer==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   boto3
 sentry-sdk==2.55.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 simplejson==3.20.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 six==1.17.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   ecdsa
     #   flask-restful
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   anyio
     #   cloudflare
 snowballstemmer==3.0.1
     # via sphinx
 sortedcontainers==2.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   fakeredis
 sphinx==8.1.3
     # via
@@ -895,7 +895,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==1.3.24
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   alembic
     #   flask-sqlalchemy
@@ -903,72 +903,72 @@ sqlalchemy==1.3.24
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 sshpubkeys==3.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   moto
 stevedore==5.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   bandit
 sympy==1.14.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cfn-lint
 tabulate==0.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
 toml==0.10.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   cert-manager
 tomli==2.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   black
     #   mypy
     #   pytest
     #   sphinx
 twofish==0.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pyjks
 types-cffi==2.0.0.20260316
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   types-pyopenssl
 types-deprecated==1.3.1.20260130
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-paramiko==4.0.0.20260322
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-protobuf==6.32.1.20260221
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-pyopenssl==24.1.0.20240722
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   types-redis
 types-pyrfc3339==2.0.1.20250825
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-pytz==2026.1.1.20260304
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-redis==4.6.0.20241004
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-requests==2.32.4.20260107
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-setuptools==82.0.0.20260210
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   types-cffi
 types-six==1.17.0.20251009
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 types-tabulate==0.10.0.20260308
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 typing-extensions==4.15.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   alembic
     #   anyio
     #   aws-sam-translator
@@ -995,21 +995,21 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   pydantic
     #   pydantic-settings
 tzdata==2025.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   arrow
     #   kombu
 tzlocal==5.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   celery
 urllib3==2.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   botocore
     #   docker
     #   requests
@@ -1017,21 +1017,21 @@ urllib3==2.6.3
     #   sentry-sdk
     #   types-requests
 validators==0.35.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    # via -r requirements-tests.txt
 vine==5.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   prompt-toolkit
 werkzeug==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   flask
     #   flask-cors
@@ -1039,17 +1039,17 @@ werkzeug==3.1.6
     #   pytest-flask
 wrapt==2.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   aws-xray-sdk
     #   deprecated
 xmltodict==1.0.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   -r requirements-docs.in
     #   moto
 zipp==3.23.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-tests.txt
+    #   -r requirements-tests.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,39 +6,39 @@
 #
 acme==5.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   certbot
 alembic==1.14.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-migrate
 alembic-autogenerate-enums==0.1.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 amqp==5.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   kombu
 aniso8601==10.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-restful
 annotated-types==0.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   pydantic
 anyio==4.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   cloudflare
     #   httpx
 arrow==1.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 async-timeout==5.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   redis
 asyncpool==1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 attrs==26.1.0
     # via
     #   jsonschema
@@ -49,12 +49,12 @@ aws-xray-sdk==2.15.0
     # via moto
 azure-common==1.1.28
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-mgmt-cdn
     #   azure-mgmt-subscription
 azure-core==1.39.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-identity
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
@@ -62,96 +62,96 @@ azure-core==1.39.0
     #   azure-mgmt-core
     #   msrest
 azure-identity==1.25.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 azure-keyvault==4.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 azure-keyvault-certificates==4.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-keyvault
 azure-keyvault-keys==4.11.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-keyvault
 azure-keyvault-secrets==4.10.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-keyvault
 azure-mgmt-cdn==13.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 azure-mgmt-core==1.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 azure-mgmt-network==30.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 azure-mgmt-subscription==3.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 bandit==1.9.4
     # via -r requirements-tests.in
 bcrypt==5.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-bcrypt
     #   paramiko
 billiard==4.2.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   celery
 black==26.3.1
     # via -r requirements-tests.in
 blinker==1.9.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask
     #   flask-mail
     #   flask-principal
 boto3==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   aws-sam-translator
     #   moto
 botocore==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
 celery[redis]==5.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   -r requirements-tests.in
 cert-manager==3.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 certbot==5.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 certifi==2026.2.25
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   httpcore
     #   httpx
     #   msrest
     #   requests
     #   sentry-sdk
 certsrv[ntlm]==2.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 cffi==2.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   cryptography
     #   pynacl
 cfn-lint==1.47.0
     # via moto
 charset-normalizer==3.4.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   requests
 click==8.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   black
     #   celery
     #   click-didyoumean
@@ -160,31 +160,31 @@ click==8.3.1
     #   flask
 click-didyoumean==0.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   celery
 click-plugins==1.1.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   celery
 cloudflare==4.3.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 configargparse==1.7.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   certbot
 configobj==5.0.9
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   certbot
 coverage==7.13.5
     # via -r requirements-tests.in
 cryptography==43.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   -r requirements-tests.in
     #   acme
     #   azure-identity
@@ -206,21 +206,21 @@ cryptography==43.0.1
     #   types-redis
 deprecated==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   limits
 distro==1.9.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   certbot
     #   cloudflare
 dnspython==2.6.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 dnspython3==1.12.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 docker==7.1.0
     # via moto
 dyn==1.8.6
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 ecdsa==0.19.1
     # via
     #   moto
@@ -228,7 +228,7 @@ ecdsa==0.19.1
     #   sshpubkeys
 exceptiongroup==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   anyio
     #   celery
     #   pytest
@@ -242,7 +242,7 @@ fakeredis==2.34.1
     # via -r requirements-tests.in
 flask==2.3.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-bcrypt
     #   flask-cors
     #   flask-limiter
@@ -254,49 +254,49 @@ flask==2.3.3
     #   flask-sqlalchemy
     #   pytest-flask
 flask-bcrypt==1.0.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-cors==6.0.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-limiter==4.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-mail==0.10.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-migrate==2.7.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-principal==0.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-replicated==2.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-restful==0.3.10
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-script==2.0.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 flask-sqlalchemy==2.5.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-migrate
 freezegun==1.5.5
     # via -r requirements-tests.in
 future==1.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 google-api-core[grpc]==2.30.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-auth==2.49.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-cloud-compute==1.46.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 google-cloud-private-ca==1.17.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 googleapis-common-protos[grpc]==1.73.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
@@ -304,11 +304,11 @@ graphql-core==3.2.8
     # via moto
 grpc-google-iam-v1==0.14.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-cloud-private-ca
 grpcio==1.78.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -317,43 +317,43 @@ grpcio==1.78.0
     #   grpcio-status
 grpcio-status==1.78.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-api-core
 gunicorn==25.1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 h11==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   httpcore
 httpcore==1.0.9
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   httpx
 httpx==0.28.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   cloudflare
 hvac==2.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 idna==3.11
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
 importlib-metadata==8.5.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 inflection==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 iniconfig==2.3.0
     # via pytest
 invoke==2.2.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   paramiko
 isodate==0.7.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
@@ -362,25 +362,25 @@ isodate==0.7.2
     #   msrest
 itsdangerous==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask
 javaobj-py3==0.4.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   pyjks
 jinja2==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask
     #   moto
 jmespath==1.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   boto3
     #   botocore
 josepy==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   acme
     #   certbot
 jsondiff==2.2.1
@@ -402,7 +402,7 @@ jsonschema-specifications==2025.9.1
     #   openapi-schema-validator
 kombu[redis]==5.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   celery
 lazy-object-proxy==1.12.0
     # via openapi-spec-validator
@@ -410,30 +410,30 @@ librt==0.8.1
     # via mypy
 limits==5.8.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-limiter
 lockfile==0.12.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 logmatic-python==0.1.7
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 mako==1.3.10
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   alembic
 markdown-it-py==4.0.0
     # via rich
 markupsafe==2.1.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   jinja2
     #   mako
     #   werkzeug
 marshmallow==2.21.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 mdurl==0.1.2
     # via markdown-it-py
 moto[all]==4.2.14
@@ -442,16 +442,16 @@ mpmath==1.3.0
     # via sympy
 msal==1.35.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-identity
     #   msal-extensions
 msal-extensions==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-identity
 msrest==0.7.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   azure-mgmt-subscription
 multipart==1.3.1
     # via moto
@@ -462,14 +462,14 @@ mypy-extensions==1.1.0
     #   black
     #   mypy
 ndg-httpsclient==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 networkx==3.4.2
     # via cfn-lint
 nose==1.3.7
     # via -r requirements-tests.in
 oauthlib==3.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   requests-oauthlib
 openapi-schema-validator==0.8.1
     # via openapi-spec-validator
@@ -479,21 +479,21 @@ openapi-spec-validator==0.8.4
     #   moto
 ordered-set==4.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-limiter
 packaging==26.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   black
     #   gunicorn
     #   kombu
     #   limits
     #   pytest
 paramiko==4.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 parsedatetime==2.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   certbot
 pathable==0.5.0
     # via jsonschema-path
@@ -502,24 +502,24 @@ pathspec==1.0.4
     #   black
     #   mypy
 pem==23.1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 platformdirs==4.9.4
     # via black
 pluggy==1.6.0
     # via pytest
 prompt-toolkit==3.0.52
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   click-repl
 proto-plus==1.27.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
 protobuf==6.33.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -528,12 +528,12 @@ protobuf==6.33.6
     #   grpcio-status
     #   proto-plus
 psycopg2==2.9.11
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 py-partiql-parser==0.5.0
     # via moto
 pyasn1==0.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   ndg-httpsclient
     #   pyasn1-modules
     #   pyjks
@@ -542,21 +542,21 @@ pyasn1==0.6.3
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   google-auth
     #   pyjks
     #   python-ldap
 pycparser==3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   pyjks
 pydantic==2.12.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   aws-sam-translator
     #   cloudflare
     #   openapi-schema-validator
@@ -564,7 +564,7 @@ pydantic==2.12.5
     #   pydantic-settings
 pydantic-core==2.41.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   pydantic
 pydantic-settings==2.13.1
     # via
@@ -577,30 +577,30 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyjks==20.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 pyjwt[crypto]==2.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   msal
 pynacl==1.6.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   acme
     #   ndg-httpsclient
 pyparsing==3.3.2
     # via moto
 pyrfc3339==2.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   acme
     #   certbot
 pyspnego==0.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   requests-ntlm
 pytest==9.0.2
     # via
@@ -613,7 +613,7 @@ pytest-mock==3.15.1
     # via -r requirements-tests.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   arrow
     #   botocore
     #   celery
@@ -625,19 +625,19 @@ python-jose[cryptography]==3.5.0
     # via moto
 python-json-logger==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   logmatic-python
 python-ldap==3.4.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 pytokens==0.4.1
     # via black
 pytz==2026.1.post1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask-restful
 pyyaml==6.0.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   bandit
     #   cfn-lint
     #   jsondiff
@@ -646,7 +646,7 @@ pyyaml==6.0.3
     #   responses
 redis==6.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   fakeredis
     #   kombu
 referencing==0.37.0
@@ -659,7 +659,7 @@ regex==2026.2.28
     # via cfn-lint
 requests==2.32.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   acme
     #   azure-core
     #   cert-manager
@@ -678,16 +678,16 @@ requests-mock==1.12.1
     # via -r requirements-tests.in
 requests-ntlm==1.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   certsrv
 requests-oauthlib==2.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   msrest
 responses==0.26.0
     # via moto
 retrying==1.4.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rich==14.3.3
@@ -700,37 +700,37 @@ rsa==4.9.1
     # via python-jose
 s3transfer==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   boto3
 sentry-sdk==2.55.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 simplejson==3.20.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   -r requirements-tests.in
 six==1.17.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   ecdsa
     #   flask-restful
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   anyio
     #   cloudflare
 sortedcontainers==2.4.0
     # via fakeredis
 sqlalchemy==1.3.24
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   alembic
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 sshpubkeys==3.3.1
     # via moto
 stevedore==5.7.0
@@ -738,10 +738,10 @@ stevedore==5.7.0
 sympy==1.14.0
     # via cfn-lint
 tabulate==0.10.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 toml==0.10.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   cert-manager
 tomli==2.4.0
     # via
@@ -750,7 +750,7 @@ tomli==2.4.0
     #   pytest
 twofish==0.3.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   pyjks
 types-cffi==2.0.0.20260316
     # via types-pyopenssl
@@ -759,7 +759,7 @@ types-deprecated==1.3.1.20260130
 types-paramiko==4.0.0.20260322
     # via -r requirements-tests.in
 types-protobuf==6.32.1.20260221
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 types-pyopenssl==24.1.0.20240722
     # via
     #   -r requirements-tests.in
@@ -782,7 +782,7 @@ types-tabulate==0.10.0.20260308
     # via -r requirements-tests.in
 typing-extensions==4.15.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   alembic
     #   anyio
     #   aws-sam-translator
@@ -809,21 +809,21 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   pydantic
     #   pydantic-settings
 tzdata==2025.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   arrow
     #   kombu
 tzlocal==5.3.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   celery
 urllib3==2.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   botocore
     #   docker
     #   requests
@@ -831,36 +831,36 @@ urllib3==2.6.3
     #   sentry-sdk
     #   types-requests
 validators==0.35.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    # via -r requirements.txt
 vine==5.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.6.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   prompt-toolkit
 werkzeug==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   flask
     #   flask-cors
     #   moto
     #   pytest-flask
 wrapt==2.1.2
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   aws-xray-sdk
     #   deprecated
 xmltodict==1.0.4
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   moto
 zipp==3.23.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements.txt
+    #   -r requirements.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@
 #
 acme==5.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   certbot
 alembic==1.14.1
     # via flask-migrate
 alembic-autogenerate-enums==0.1.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 amqp==5.3.1
     # via kombu
 aniso8601==10.0.1
@@ -20,15 +20,15 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.5.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-datadog.in
     #   cloudflare
     #   httpx
 arrow==1.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 async-timeout==5.0.1
     # via redis
 asyncpool==1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 azure-common==1.1.28
     # via
     #   azure-mgmt-cdn
@@ -42,9 +42,9 @@ azure-core==1.39.0
     #   azure-mgmt-core
     #   msrest
 azure-identity==1.25.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 azure-keyvault==4.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 azure-keyvault-certificates==4.10.0
     # via azure-keyvault
 azure-keyvault-keys==4.11.0
@@ -52,16 +52,16 @@ azure-keyvault-keys==4.11.0
 azure-keyvault-secrets==4.10.0
     # via azure-keyvault
 azure-mgmt-cdn==13.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 azure-mgmt-core==1.6.0
     # via
     #   azure-mgmt-cdn
     #   azure-mgmt-network
     #   azure-mgmt-subscription
 azure-mgmt-network==30.2.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 azure-mgmt-subscription==3.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 bcrypt==5.0.0
     # via
     #   flask-bcrypt
@@ -74,28 +74,28 @@ blinker==1.9.0
     #   flask-mail
     #   flask-principal
 boto3==1.42.73
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 botocore==1.42.73
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   boto3
     #   s3transfer
 celery[redis]==5.6.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 cert-manager==3.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 certbot==5.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 certifi==2026.2.25
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   httpcore
     #   httpx
     #   msrest
     #   requests
     #   sentry-sdk
 certsrv[ntlm]==2.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 cffi==2.0.0
     # via
     #   cryptography
@@ -116,15 +116,15 @@ click-plugins==1.1.1.2
 click-repl==0.3.0
     # via celery
 cloudflare==4.3.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 configargparse==1.7.5
     # via certbot
 configobj==5.0.9
     # via certbot
 cryptography==43.0.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-base.in
+    #   -r requirements-datadog.in
     #   acme
     #   azure-identity
     #   azure-keyvault-keys
@@ -144,18 +144,18 @@ distro==1.9.0
     #   certbot
     #   cloudflare
 dnspython==2.6.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 dnspython3==1.12.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 dyn==1.8.6
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 exceptiongroup==1.3.1
     # via
     #   anyio
     #   celery
 flask==2.3.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   flask-bcrypt
     #   flask-cors
     #   flask-limiter
@@ -166,31 +166,31 @@ flask==2.3.3
     #   flask-script
     #   flask-sqlalchemy
 flask-bcrypt==1.0.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-cors==6.0.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-limiter==4.1.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-mail==0.10.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-migrate==2.7.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-base.in
+    #   -r requirements-datadog.in
 flask-principal==0.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-replicated==2.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-restful==0.3.10
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 flask-script==2.0.5
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 flask-sqlalchemy==2.5.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   flask-migrate
 future==1.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 google-api-core[grpc]==2.30.0
     # via
     #   google-cloud-compute
@@ -201,9 +201,9 @@ google-auth==2.49.1
     #   google-cloud-compute
     #   google-cloud-private-ca
 google-cloud-compute==1.46.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 google-cloud-private-ca==1.17.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 googleapis-common-protos[grpc]==1.73.0
     # via
     #   google-api-core
@@ -222,26 +222,26 @@ grpcio==1.78.0
 grpcio-status==1.78.0
     # via google-api-core
 gunicorn==25.1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 h11==0.16.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-datadog.in
     #   httpcore
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via cloudflare
 hvac==2.4.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 idna==3.11
     # via
     #   anyio
     #   httpx
     #   requests
 importlib-metadata==8.5.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 inflection==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 invoke==2.2.1
     # via paramiko
 isodate==0.7.2
@@ -254,14 +254,14 @@ isodate==0.7.2
     #   msrest
 itsdangerous==2.2.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   flask
 javaobj-py3==0.4.4
     # via pyjks
 jinja2==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-base.in
+    #   -r requirements-datadog.in
     #   flask
 jmespath==1.1.0
     # via
@@ -276,23 +276,23 @@ kombu[redis]==5.6.2
 limits==5.8.0
     # via flask-limiter
 lockfile==0.12.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 logmatic-python==0.1.7
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 mako==1.3.10
     # via alembic
 markupsafe==2.1.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-datadog.in
     #   jinja2
     #   mako
     #   werkzeug
 marshmallow==2.21.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 msal==1.35.1
     # via
     #   azure-identity
@@ -302,7 +302,7 @@ msal-extensions==1.3.1
 msrest==0.7.1
     # via azure-mgmt-subscription
 ndg-httpsclient==0.5.1
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 oauthlib==3.3.1
     # via requests-oauthlib
 ordered-set==4.1.0
@@ -313,11 +313,11 @@ packaging==26.0
     #   kombu
     #   limits
 paramiko==4.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 parsedatetime==2.6
     # via certbot
 pem==23.1.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 prompt-toolkit==3.0.52
     # via click-repl
 proto-plus==1.27.1
@@ -327,7 +327,7 @@ proto-plus==1.27.1
     #   google-cloud-private-ca
 protobuf==6.33.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-private-ca
@@ -336,7 +336,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   proto-plus
 psycopg2==2.9.11
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 pyasn1==0.6.3
     # via
     #   ndg-httpsclient
@@ -357,16 +357,16 @@ pydantic==2.12.5
 pydantic-core==2.41.5
     # via pydantic
 pyjks==20.0.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 pyjwt[crypto]==2.12.1
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   msal
 pynacl==1.6.2
     # via paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   acme
     #   ndg-httpsclient
 pyrfc3339==2.1.0
@@ -382,23 +382,23 @@ python-dateutil==2.9.0.post0
     #   celery
 python-json-logger==4.0.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   logmatic-python
 python-ldap==3.4.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-base.in
+    #   -r requirements-datadog.in
 pytz==2026.1.post1
     # via flask-restful
 pyyaml==6.0.3
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 redis==6.4.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   kombu
 requests==2.32.5
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   acme
     #   azure-core
     #   cert-manager
@@ -414,16 +414,16 @@ requests-ntlm==1.3.0
 requests-oauthlib==2.0.0
     # via msrest
 retrying==1.4.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 s3transfer==0.16.0
     # via boto3
 sentry-sdk==2.55.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 simplejson==3.20.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    # via -r requirements-datadog.in
 six==1.17.0
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   flask-restful
     #   python-dateutil
 sniffio==1.3.1
@@ -432,21 +432,21 @@ sniffio==1.3.1
     #   cloudflare
 sqlalchemy==1.3.24
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   alembic
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 tabulate==0.10.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 toml==0.10.2
     # via cert-manager
 twofish==0.3.0
     # via pyjks
 types-protobuf==6.32.1.20260221
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 typing-extensions==4.15.0
     # via
     #   alembic
@@ -477,12 +477,12 @@ tzlocal==5.3.1
     # via celery
 urllib3==2.6.3
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-datadog.in
+    #   -r requirements-datadog.in
     #   botocore
     #   requests
     #   sentry-sdk
 validators==0.35.0
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 vine==5.1.0
     # via
     #   amqp
@@ -492,12 +492,12 @@ wcwidth==0.6.0
     # via prompt-toolkit
 werkzeug==3.1.6
     # via
-    #   -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    #   -r requirements-base.in
     #   flask
     #   flask-cors
 wrapt==2.1.2
     # via deprecated
 xmltodict==1.0.4
-    # via -r /Users/maxime.perusse/go/src/github.com/DataDog/lemur/requirements-base.in
+    # via -r requirements-base.in
 zipp==3.23.0
     # via importlib-metadata


### PR DESCRIPTION
The compiled requirements*.txt files had absolute paths from whichever machine pip-compile was last run on — every "via -r" comment referenced a personal home directory (/Users/maxime.perusse/go/src/github.com/DataDog/lemur/...). Replacing with the correct relative paths so the files don't carry environmental noise from whoever generated them last.

Pure text substitution, 670 lines changed (335 occurrences each replaced with the relative form). No dependency or version changes.

Generated by:

    sed -i '' 's|/Users/maxime.perusse/go/src/github.com/DataDog/lemur/||g' \
      requirements.txt requirements-dev.txt requirements-docs.txt requirements-tests.txt

Long term, make up-reqs should be run from the repo root so the paths stay relative, or pip-compile should be invoked with --no-strip-extras and an explicit --output-file relative path. Worth a follow-up to the Makefile if this keeps happening.