### PR TITLE
expose sources field on certificate output schema

### DIFF
--- a/lemur/certificates/schemas.py
+++ b/lemur/certificates/schemas.py
@@ -33,6 +33,7 @@ from lemur.notifications.schemas import NotificationNestedOutputSchema
 from lemur.policies.schemas import RotationPolicyNestedOutputSchema
 from lemur.roles import service as roles_service
 from lemur.roles.schemas import RoleNestedOutputSchema
+from lemur.sources.schemas import SourceNestedOutputSchema
 from lemur.schemas import (
     AssociatedAuthoritySchema,
     AssociatedDestinationSchema,
@@ -382,6 +383,7 @@ class CertificateOutputSchema(LemurOutputSchema):
     # associated objects
     domains = fields.Nested(DomainNestedOutputSchema, many=True)
     destinations = fields.Nested(DestinationNestedOutputSchema, many=True)
+    sources = fields.Nested(SourceNestedOutputSchema, many=True)
     notifications = fields.Nested(NotificationNestedOutputSchema, many=True)
     replaces = fields.Nested(CertificateNestedOutputSchema, many=True)
     authority = fields.Nested(AuthorityNestedOutputSchema)

--- a/lemur/sources/schemas.py
+++ b/lemur/sources/schemas.py
@@ -35,6 +35,10 @@ class SourceOutputSchema(LemurOutputSchema):
         return data
 
 
+class SourceNestedOutputSchema(SourceOutputSchema):
+    __envelope__ = False
+
+
 source_input_schema = SourceInputSchema()
 sources_output_schema = SourceOutputSchema(many=True)
 source_output_schema = SourceOutputSchema()


### PR DESCRIPTION
The Certificate model has a `sources` relationship but `CertificateOutputSchema` never declared the field, so the REST API returned `sources: null` on every cert even when the DB had active associations. Surfaced during a sandbox audit where `/api/1/certificates` returned no provenance for any cert, while the `certificate_source_associations` table had 271 rows.

Mirrors the pattern already used for `destinations`, `notifications`, `endpoints`, etc.: add a `SourceNestedOutputSchema` (with `__envelope__ = False`) in `lemur/sources/schemas.py` and declare `sources = fields.Nested(SourceNestedOutputSchema, many=True)` on `CertificateOutputSchema`.

Verified locally that the underlying data is there (queried `certificate_source_associations` via `lemur shell` in the sandbox pod). After this change, `GET /api/1/certificates/{id}` will include the associated sources alongside destinations and notifications.

This is an upstream Netflix/lemur omission; worth pushing back upstream as a small follow-up.