### PR TITLE
show environment label in navbar header

### DIFF
--- a/lemur/static/app/index.html
+++ b/lemur/static/app/index.html
@@ -44,7 +44,16 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="/#/">Lemur</a>
+                <a class="navbar-brand" href="/#/" id="lemur-brand">Lemur</a>
+                <script>
+                  (function () {
+                    var h = location.hostname, l = '';
+                    if (h.indexOf('sandbox') >= 0) l = ' - development';
+                    else if (h.indexOf('commercial') >= 0) l = ' - commercial';
+                    else if (h.indexOf('government') >= 0) l = ' - government';
+                    if (l) { document.getElementById('lemur-brand').textContent = 'Lemur' + l; document.title = 'Lemur' + l; }
+                  })();
+                </script>
             </div>
             <div class="navbar-collapse collapse" ng-controller="LoginController">
                 <ul class="nav navbar-nav navbar-left">

--- a/lemur/static/app/index.html
+++ b/lemur/static/app/index.html
@@ -48,9 +48,9 @@
                 <script>
                   (function () {
                     var h = location.hostname, l = '';
-                    if (h.indexOf('us1.staging.dog') >= 0) l = ' - development';
-                    else if (h.indexOf('us1.ddbuild.io') >= 0) l = ' - commercial';
-                    else if (h.indexOf('us1-build.fed') >= 0) l = ' - government';
+                    if (h.endsWith('.us1.staging.dog')) l = ' - development';
+                    else if (h.endsWith('.us1.ddbuild.io')) l = ' - commercial';
+                    else if (h.endsWith('.us1-build.fed.dog')) l = ' - government';
                     if (l) { document.getElementById('lemur-brand').textContent = 'Lemur' + l; document.title = 'Lemur' + l; }
                   })();
                 </script>

--- a/lemur/static/app/index.html
+++ b/lemur/static/app/index.html
@@ -48,9 +48,9 @@
                 <script>
                   (function () {
                     var h = location.hostname, l = '';
-                    if (h.indexOf('sandbox') >= 0) l = ' - development';
-                    else if (h.indexOf('commercial') >= 0) l = ' - commercial';
-                    else if (h.indexOf('government') >= 0) l = ' - government';
+                    if (h.indexOf('us1.staging.dog') >= 0) l = ' - development';
+                    else if (h.indexOf('us1.ddbuild.io') >= 0) l = ' - commercial';
+                    else if (h.indexOf('us1-build.fed') >= 0) l = ' - government';
                     if (l) { document.getElementById('lemur-brand').textContent = 'Lemur' + l; document.title = 'Lemur' + l; }
                   })();
                 </script>


### PR DESCRIPTION
Append the deployment env to the navbar brand (and document title) based on hostname:

- `lemur-sandbox.*` → `Lemur - development`
- `lemur-commercial.*` → `Lemur - commercial`
- `lemur-government.*` → `Lemur - government`
- anything else → plain `Lemur` (fallback)

Helps tell which instance you're on at a glance, especially during the upcoming dev/commercial split work.

Hostname sniff in inline JS rather than a backend endpoint to keep the change tiny (+10/-1 in one file). Can revisit with a proper `/api/1/instance` endpoint later if we want to decouple from URL naming. Considering we will migrate to Mosaic, not worth it for now