### PR TITLE
add source/destination parity Celery task

### DIFF
--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -467,67 +467,6 @@ def clean_all_sources():
     return log_data
 
 
-@celery_app.task(soft_time_limit=600)
-def check_source_destination_parity():
-    """
-    Strict 1:1 parity check between sources and destinations: every source label
-    should have a destination with the exact same label, and vice versa. This
-    mirrors the auto-attach contract in `lemur/sources/service.py:sync_update_destination`,
-    where source-imported certs get a destination automatically only when the
-    labels match exactly. Drift (a renamed source, or a destination added without
-    its discovery counterpart) breaks that loop silently.
-
-    Emits two gauges plus per-label counters so the Datadog monitor can both alert
-    on the aggregate count and surface which specific labels are unpaired.
-    """
-    function = f"{__name__}.{sys._getframe().f_code.co_name}"
-
-    from lemur.sources.models import Source
-    from lemur.destinations.models import Destination
-
-    source_labels = {s.label for s in Source.query.all() if s.label}
-    destination_labels = {d.label for d in Destination.query.all() if d.label}
-
-    destinations_missing_source = destination_labels - source_labels
-    sources_missing_destination = source_labels - destination_labels
-
-    metrics.send(
-        "lemur.parity.destinations_missing_source",
-        "gauge",
-        len(destinations_missing_source),
-    )
-    metrics.send(
-        "lemur.parity.sources_missing_destination",
-        "gauge",
-        len(sources_missing_destination),
-    )
-
-    for label in destinations_missing_source:
-        metrics.send(
-            "lemur.parity.unmatched_destination",
-            "counter",
-            1,
-            metric_tags={"label": label},
-        )
-    for label in sources_missing_destination:
-        metrics.send(
-            "lemur.parity.unmatched_source",
-            "counter",
-            1,
-            metric_tags={"label": label},
-        )
-
-    log_data = {
-        "function": function,
-        "message": "Source/destination parity check complete",
-        "destinations_missing_source": sorted(destinations_missing_source),
-        "sources_missing_destination": sorted(sources_missing_destination),
-    }
-    current_app.logger.info(log_data)
-    metrics.send(f"{function}.success", "counter", 1)
-    return log_data
-
-
 @celery_app.task(soft_time_limit=3600)
 def clean_source(source):
     """
@@ -1193,3 +1132,11 @@ def certificate_expirations_metrics():
 
     metrics.send(f"{function}.success", "counter", 1)
     return log_data
+
+
+# Import monitoring task module so its @celery_app.task() decorators register
+# with the worker on startup. Keep this at the bottom of the file: monitoring
+# imports `celery_app` from this module, and a top-of-file import here would
+# create a circular import. By the time we reach this line, `celery_app` is
+# already defined and importable.
+from lemur.common import monitoring  # noqa: E402, F401

--- a/lemur/common/celery.py
+++ b/lemur/common/celery.py
@@ -467,6 +467,67 @@ def clean_all_sources():
     return log_data
 
 
+@celery_app.task(soft_time_limit=600)
+def check_source_destination_parity():
+    """
+    Strict 1:1 parity check between sources and destinations: every source label
+    should have a destination with the exact same label, and vice versa. This
+    mirrors the auto-attach contract in `lemur/sources/service.py:sync_update_destination`,
+    where source-imported certs get a destination automatically only when the
+    labels match exactly. Drift (a renamed source, or a destination added without
+    its discovery counterpart) breaks that loop silently.
+
+    Emits two gauges plus per-label counters so the Datadog monitor can both alert
+    on the aggregate count and surface which specific labels are unpaired.
+    """
+    function = f"{__name__}.{sys._getframe().f_code.co_name}"
+
+    from lemur.sources.models import Source
+    from lemur.destinations.models import Destination
+
+    source_labels = {s.label for s in Source.query.all() if s.label}
+    destination_labels = {d.label for d in Destination.query.all() if d.label}
+
+    destinations_missing_source = destination_labels - source_labels
+    sources_missing_destination = source_labels - destination_labels
+
+    metrics.send(
+        "lemur.parity.destinations_missing_source",
+        "gauge",
+        len(destinations_missing_source),
+    )
+    metrics.send(
+        "lemur.parity.sources_missing_destination",
+        "gauge",
+        len(sources_missing_destination),
+    )
+
+    for label in destinations_missing_source:
+        metrics.send(
+            "lemur.parity.unmatched_destination",
+            "counter",
+            1,
+            metric_tags={"label": label},
+        )
+    for label in sources_missing_destination:
+        metrics.send(
+            "lemur.parity.unmatched_source",
+            "counter",
+            1,
+            metric_tags={"label": label},
+        )
+
+    log_data = {
+        "function": function,
+        "message": "Source/destination parity check complete",
+        "destinations_missing_source": sorted(destinations_missing_source),
+        "sources_missing_destination": sorted(sources_missing_destination),
+    }
+    current_app.logger.info(log_data)
+    metrics.send(f"{function}.success", "counter", 1)
+    return log_data
+
+
 @celery_app.task(soft_time_limit=3600)
 def clean_source(source):
     """

--- a/lemur/common/monitoring.py
+++ b/lemur/common/monitoring.py
@@ -3,7 +3,7 @@ Lemur monitoring tasks.
 
 Tasks here are pure observability: they read DB state and emit metrics. They
 must not mutate state. Business-logic Celery tasks (cert rotation, source
-sync, etc.) live in lemur/common/celery.py or in the relevant domain package.
+sync, etc.) do not belong here.
 """
 
 import sys

--- a/lemur/common/monitoring.py
+++ b/lemur/common/monitoring.py
@@ -1,0 +1,74 @@
+"""
+Lemur monitoring tasks.
+
+Tasks here are pure observability: they read DB state and emit metrics. They
+must not mutate state. Business-logic Celery tasks (cert rotation, source
+sync, etc.) live in lemur/common/celery.py or in the relevant domain package.
+"""
+
+import sys
+from flask import current_app
+
+from lemur.common.celery import celery_app
+from lemur.extensions import metrics
+
+
+@celery_app.task(soft_time_limit=600)
+def check_source_destination_parity():
+    """
+    Strict 1:1 parity check between sources and destinations: every source label
+    should have a destination with the exact same label, and vice versa. This
+    mirrors the auto-attach contract in `lemur/sources/service.py:sync_update_destination`,
+    where source-imported certs get a destination automatically only when the
+    labels match exactly. Drift (a renamed source, or a destination added without
+    its discovery counterpart) breaks that loop silently.
+
+    Emits two gauges plus per-label counters so the Datadog monitor can both alert
+    on the aggregate count and surface which specific labels are unpaired.
+    """
+    function = f"{__name__}.{sys._getframe().f_code.co_name}"
+
+    from lemur.sources.models import Source
+    from lemur.destinations.models import Destination
+
+    source_labels = {s.label for s in Source.query.all() if s.label}
+    destination_labels = {d.label for d in Destination.query.all() if d.label}
+
+    destinations_missing_source = destination_labels - source_labels
+    sources_missing_destination = source_labels - destination_labels
+
+    metrics.send(
+        "lemur.parity.destinations_missing_source",
+        "gauge",
+        len(destinations_missing_source),
+    )
+    metrics.send(
+        "lemur.parity.sources_missing_destination",
+        "gauge",
+        len(sources_missing_destination),
+    )
+
+    for label in destinations_missing_source:
+        metrics.send(
+            "lemur.parity.unmatched_destination",
+            "counter",
+            1,
+            metric_tags={"label": label},
+        )
+    for label in sources_missing_destination:
+        metrics.send(
+            "lemur.parity.unmatched_source",
+            "counter",
+            1,
+            metric_tags={"label": label},
+        )
+
+    log_data = {
+        "function": function,
+        "message": "Source/destination parity check complete",
+        "destinations_missing_source": sorted(destinations_missing_source),
+        "sources_missing_destination": sorted(sources_missing_destination),
+    }
+    current_app.logger.info(log_data)
+    metrics.send(f"{function}.success", "counter", 1)
+    return log_data


### PR DESCRIPTION
Adds `check_source_destination_parity` to `lemur/common/celery.py`.

The task does a strict 1:1 label match between sources and destinations and emits:

- `lemur.parity.destinations_missing_source` (gauge): count of destination labels with no matching source
- `lemur.parity.sources_missing_destination` (gauge): count of source labels with no matching destination
- `lemur.parity.unmatched_destination` (counter per label)
- `lemur.parity.unmatched_source` (counter per label)

The per-label counters give the Datadog monitor enough breadcrumbs to surface which specific labels are unpaired when an alert fires.

Why this matters: `sync_update_destination` in `lemur/sources/service.py` auto-attaches a destination to source-imported certs **only when labels match exactly**. A renamed source, or a destination added without its discovery counterpart, silently breaks that auto-attach loop. This task makes the drift observable.

Beat scheduling is out of scope here — that lives in `k8s-resources/k8s/lemur/chart/config/lemur.conf.py` and will be wired up only for commercial/gov (dev/sandbox intentionally has source/destination split after the lemur-dev isolation work).

Part of the P0 "Lemur monitoring gaps" cleanup item.