### PR TITLE
Install dd-source wheels in the local dev Docker image

### DIFF
--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -96,10 +96,7 @@ RUN apt-get purge -y --auto-remove \
 # Install development and test dependencies
 RUN pip install --no-cache-dir -e ."[dev]" -e ."[tests]"
 
-# Datadog internal wheels (cert_orchestration_adapter + dd_internal_authentication)
-# and their transitive deps such as cachetools, which lemur/auth/vault_jwt_auth.py
-# imports. make develop installs these on the host; the image needs them too or
-# lemur fails to import and the container crash-loops.
+# The image needs Datadog internal wheels
 RUN pip3 install --no-cache-dir -r requirements-dd-source.in
 
 COPY local/src/lemur.conf.py /home/lemur/.lemur/lemur.conf.py

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -96,6 +96,12 @@ RUN apt-get purge -y --auto-remove \
 # Install development and test dependencies
 RUN pip install --no-cache-dir -e ."[dev]" -e ."[tests]"
 
+# Datadog internal wheels (cert_orchestration_adapter + dd_internal_authentication)
+# and their transitive deps such as cachetools, which lemur/auth/vault_jwt_auth.py
+# imports. make develop installs these on the host; the image needs them too or
+# lemur fails to import and the container crash-loops.
+RUN pip3 install --no-cache-dir -r requirements-dd-source.in
+
 COPY local/src/lemur.conf.py /home/lemur/.lemur/lemur.conf.py
 COPY local/create_defaults.py /home/lemur/.lemur/create_defaults.py
 COPY local/testing/ /opt/lemur/local/testing/


### PR DESCRIPTION
The local dev container (local/Dockerfile) crash-loops on startup. It runs pip install -e . but never installs requirements-dd-source.in, so the cert_orchestration_adapter and dd_internal_authentication wheels and their transitive deps (notably cachetools) are missing from the image. lemur/auth/vault_jwt_auth.py imports cachetools, so lemur fails to import and the container restarts in a loop, which makes cd local && docker-compose up unusable.

make develop installs those wheels on the host and the prod publish image installs them too, so the local image was the odd one out. This adds the same pip install -r requirements-dd-source.in step to local/Dockerfile.

Verified in a workspace: rebuilt the image, the container comes up healthy, the UI loads on https and the default TestCA authority and users are created.