### PR TITLE
fix authority_id not persisting on certificate create/reissue (CLOUDR-1919)

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -234,6 +234,16 @@ class Certificate(db.Model):
         self.bits = defaults.bitstrength(cert)
         self.external_id = kwargs.get("external_id")
         self.authority_id = kwargs.get("authority_id")
+        # Most callers (create, reissue) pass the resolved Authority object as `authority`
+        # rather than `authority_id`. Historically the FK was populated only by a later
+        # `cert.authority = ...` relationship assignment in the service layer, and that
+        # relationship->FK sync could fail to flush under the bulk reissue task, leaving
+        # authority_id NULL. A cert with a NULL authority can never be reissued (the
+        # rotation pipeline can't resolve a CA), so set the FK directly from the object
+        # here. Imported certs legitimately have no authority, so only do this when one
+        # was actually provided.
+        if self.authority_id is None and kwargs.get("authority") is not None:
+            self.authority_id = kwargs["authority"].id
         self.dns_provider_id = kwargs.get("dns_provider_id")
 
         for domain in defaults.domains(cert):

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -234,14 +234,6 @@ class Certificate(db.Model):
         self.bits = defaults.bitstrength(cert)
         self.external_id = kwargs.get("external_id")
         self.authority_id = kwargs.get("authority_id")
-        # Most callers (create, reissue) pass the resolved Authority object as `authority`
-        # rather than `authority_id`. Historically the FK was populated only by a later
-        # `cert.authority = ...` relationship assignment in the service layer, and that
-        # relationship->FK sync could fail to flush under the bulk reissue task, leaving
-        # authority_id NULL. A cert with a NULL authority can never be reissued (the
-        # rotation pipeline can't resolve a CA), so set the FK directly from the object
-        # here. Imported certs legitimately have no authority, so only do this when one
-        # was actually provided.
         if self.authority_id is None and kwargs.get("authority") is not None:
             self.authority_id = kwargs["authority"].id
         self.dns_provider_id = kwargs.get("dns_provider_id")

--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -233,9 +233,7 @@ class Certificate(db.Model):
         self.signing_algorithm = defaults.signing_algorithm(cert)
         self.bits = defaults.bitstrength(cert)
         self.external_id = kwargs.get("external_id")
-        self.authority_id = kwargs.get("authority_id")
-        if self.authority_id is None and kwargs.get("authority") is not None:
-            self.authority_id = kwargs["authority"].id
+        self.authority_id = kwargs.get("authority_id") or getattr(kwargs.get("authority"), "id", None)
         self.dns_provider_id = kwargs.get("dns_provider_id")
 
         for domain in defaults.domains(cert):

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -41,6 +41,31 @@ from lemur.tests.vectors import (
 )
 
 
+def test_certificate_init_sets_authority_id_from_authority(session):
+    # Regression: create()/reissue construct a Certificate with the `authority` object
+    # (not `authority_id`). The FK must be populated directly here, not left to a later
+    # relationship assignment that can fail to flush under the bulk reissue task and
+    # leave authority_id NULL (which permanently breaks future rotations).
+    from lemur.certificates.models import Certificate
+    from lemur.tests.factories import AuthorityFactory
+
+    authority = AuthorityFactory()
+    session.commit()
+
+    cert = Certificate(body=SAN_CERT_STR, owner="joe@example.com", authority=authority)
+
+    assert cert.authority_id == authority.id
+
+
+def test_certificate_init_allows_no_authority(session):
+    # Imported certs legitimately have no Lemur authority; authority_id must stay None.
+    from lemur.certificates.models import Certificate
+
+    cert = Certificate(body=SAN_CERT_STR, owner="joe@example.com")
+
+    assert cert.authority_id is None
+
+
 def test_get_or_increase_name(session, certificate):
     from lemur.certificates.models import get_or_increase_name
     from lemur.tests.factories import CertificateFactory

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -42,10 +42,7 @@ from lemur.tests.vectors import (
 
 
 def test_certificate_init_sets_authority_id_from_authority(session):
-    # Regression: create()/reissue construct a Certificate with the `authority` object
-    # (not `authority_id`). The FK must be populated directly here, not left to a later
-    # relationship assignment that can fail to flush under the bulk reissue task and
-    # leave authority_id NULL (which permanently breaks future rotations).
+    # Regression: create()/reissue construct a Certificate with the `authority` object (not `authority_id`).
     from lemur.certificates.models import Certificate
     from lemur.tests.factories import AuthorityFactory
 

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -63,6 +63,19 @@ def test_certificate_init_allows_no_authority(session):
     assert cert.authority_id is None
 
 
+def test_certificate_init_transient_authority_leaves_id_none(session):
+    # An authority with no id yet (e.g. not flushed) must not raise; authority_id stays None.
+    from lemur.certificates.models import Certificate
+    from lemur.tests.factories import AuthorityFactory
+
+    transient = AuthorityFactory.build()
+    assert transient.id is None
+
+    cert = Certificate(body=SAN_CERT_STR, owner="joe@example.com", authority=transient)
+
+    assert cert.authority_id is None
+
+
 def test_get_or_increase_name(session, certificate):
     from lemur.certificates.models import get_or_increase_name
     from lemur.tests.factories import CertificateFactory


### PR DESCRIPTION
On reissue, certificates can be persisted with authority_id = NULL, which permanently breaks rotation because the pipeline cannot resolve a CA to mint a successor. Cert 1551 (*.us1.staging-fed.dog) hit this and was about to expire on a live endpoint with no successor.

Root cause: Certificate.__init__ populated authority_id only from a kwargs["authority_id"] key, but create() and reissue_certificate construct the cert with the resolved Authority object under kwargs["authority"] (no authority_id) and then set the link separately via cert.authority = ... just before commit. That relies on SQLAlchemy back-populating the FK from the relationship at flush, which can fail to take under the bulk certificate_reissue celery task session/flush timing, leaving authority_id NULL even though a valid authority was provided and passed validation. This matches the intermittent, date-clustered occurrences seen in prod.

This sets the FK directly from the authority object in the constructor when one is provided, so the link cannot be lost to relationship/flush timing. Imported certs legitimately have no authority and are unaffected (authority_id stays None when no authority is passed). Adds regression tests; full suite passes end to end (817 passed, 18 skipped).

Not specific to our fork: Netflix/lemur main has the identical pattern (authority_id set only from the authority_id kwarg in the constructor, with the link established separately at create time):
- https://github.com/Netflix/lemur/blob/e9ade7dad5c9bc1369a831554ed6df3277c9cbae/lemur/certificates/models.py#L225
- https://github.com/Netflix/lemur/blob/e9ade7dad5c9bc1369a831554ed6df3277c9cbae/lemur/certificates/service.py#L534-L543

Upstream issue: https://github.com/Netflix/lemur/issues/5447

Jira:
- Root cause: https://datadoghq.atlassian.net/browse/CLOUDR-1919
- Cert 1551 remediation: https://datadoghq.atlassian.net/browse/CLOUDR-1946