### PR TITLE
set authority_id in PendingCertificate.__init__ (ACME path; follow-up to #316, CLOUDR-1919)

### DIFF
--- a/lemur/pending_certificates/models.py
+++ b/lemur/pending_certificates/models.py
@@ -138,6 +138,7 @@ class PendingCertificate(db.Model):
             # If the request does not send private key, the key exists but the value is None
             self.private_key = self.private_key.strip()
         self.external_id = kwargs.get("external_id")
+        self.authority_id = kwargs.get("authority_id") or getattr(kwargs.get("authority"), "id", None)
 
         # when destinations are appended they require a valid name.
         if kwargs.get("name"):

--- a/lemur/tests/test_pending_certificates.py
+++ b/lemur/tests/test_pending_certificates.py
@@ -14,6 +14,23 @@ from .vectors import (
 )
 
 
+def test_pending_certificate_init_sets_authority_id_from_authority(session):
+    # The ACME/async path goes through PendingCertificate, which must also set authority_id
+    # from the authority object (not rely on a later relationship assignment that can leave
+    # it NULL under the reissue race; see Netflix/lemur#5447). The resolved cert inherits this.
+    from lemur.pending_certificates.models import PendingCertificate
+    from lemur.tests.factories import AuthorityFactory
+
+    authority = AuthorityFactory()
+    session.commit()
+
+    pc = PendingCertificate(
+        csr=CSR_STR, authority=authority, owner="joe@example.com", name="pending-authfix-test"
+    )
+
+    assert pc.authority_id == authority.id
+
+
 def test_increment_attempt(pending_certificate):
     from lemur.pending_certificates.service import increment_attempt
 

--- a/lemur/tests/test_pending_certificates.py
+++ b/lemur/tests/test_pending_certificates.py
@@ -15,9 +15,6 @@ from .vectors import (
 
 
 def test_pending_certificate_init_sets_authority_id_from_authority(session):
-    # The ACME/async path goes through PendingCertificate, which must also set authority_id
-    # from the authority object (not rely on a later relationship assignment that can leave
-    # it NULL under the reissue race; see Netflix/lemur#5447). The resolved cert inherits this.
     from lemur.pending_certificates.models import PendingCertificate
     from lemur.tests.factories import AuthorityFactory
 


### PR DESCRIPTION
Follow-up to #316, which fixed Certificate.__init__ to set authority_id directly from the authority object. The async/ACME path has the identical gap and this closes it.

PendingCertificate.__init__ never set authority_id; it relied on the same post-init cert.authority = ... relationship assignment in create() that can leave the FK NULL under the bulk certificate_reissue session/flush timing. The ACME resolution then copies the pending cert forward via data.update(vars(pending_certificate)), so a null on the pending cert yields a null-authority resolved Certificate. Let's Encrypt / ACME certs were therefore exposed to the same issue (Netflix/lemur#5447) as the DigiCert/Sectigo certs #316 covered.

Prod has no ACME certs today, so this is not an active prod incident, but fixing it closes the class so the guarantee holds if ACME is ever used.

Fix: set authority_id directly from the authority object in PendingCertificate.__init__, using the same getattr(..., "id", None) form as #316 so a transient authority (no id yet) still falls through to the existing relationship back-fill. Adds a regression test. Full suite passes (819 passed, 18 skipped), and I confirmed in sandbox that PendingCertificate.__init__ left authority_id None prior to this change while the fixed Certificate set it.

Upstream issue: https://github.com/Netflix/lemur/issues/5447
Jira: https://datadoghq.atlassian.net/browse/CLOUDR-1919