### PR TITLE
persist user_id (and PendingCertificate authority_id) directly in __init__

### DIFF
--- a/lemur/certificates/models.py
+++ b/lemur/certificates/models.py
@@ -233,7 +233,8 @@ class Certificate(db.Model):
         self.signing_algorithm = defaults.signing_algorithm(cert)
         self.bits = defaults.bitstrength(cert)
         self.external_id = kwargs.get("external_id")
-        self.authority_id = kwargs.get("authority_id") or getattr(kwargs.get("authority"), "id", None)
+        self.authority_id = kwargs.get("authority_id") or getattr(kwargs.get("authority"), "id", None)  # authority_id if passed, else derive it from the authority object
+        self.user_id = kwargs.get("user_id") or getattr(kwargs.get("creator"), "id", None)  # user_id if passed, else derive it from the creator object
         self.dns_provider_id = kwargs.get("dns_provider_id")
 
         for domain in defaults.domains(cert):

--- a/lemur/pending_certificates/models.py
+++ b/lemur/pending_certificates/models.py
@@ -138,6 +138,8 @@ class PendingCertificate(db.Model):
             # If the request does not send private key, the key exists but the value is None
             self.private_key = self.private_key.strip()
         self.external_id = kwargs.get("external_id")
+        self.authority_id = kwargs.get("authority_id") or getattr(kwargs.get("authority"), "id", None)  # authority_id if passed, else derive it from the authority object
+        self.user_id = kwargs.get("user_id") or getattr(kwargs.get("creator"), "id", None)  # user_id if passed, else derive it from the creator object
 
         # when destinations are appended they require a valid name.
         if kwargs.get("name"):

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -77,10 +77,7 @@ def test_certificate_init_transient_authority_leaves_id_none(session):
 
 
 def test_certificate_init_sets_user_id_from_creator(session):
-    # create()/reissue construct a Certificate with the `creator` user object (not `user_id`).
-    # Persist user_id at construction so it lands in the INSERT, not a deferrable post-INSERT
-    # UPDATE the bulk certificate_reissue task can lose. Same fix/shape as authority_id (#316);
-    # a NULL user_id later crashes reissue on creator=None. See CLOUDR-1948 / Netflix/lemur#5447.
+    # Regression: create()/reissue construct a Certificate with the `creator` object (not `creator_id`).
     from lemur.certificates.models import Certificate
     from lemur.tests.factories import UserFactory
 

--- a/lemur/tests/test_certificates.py
+++ b/lemur/tests/test_certificates.py
@@ -76,6 +76,31 @@ def test_certificate_init_transient_authority_leaves_id_none(session):
     assert cert.authority_id is None
 
 
+def test_certificate_init_sets_user_id_from_creator(session):
+    # create()/reissue construct a Certificate with the `creator` user object (not `user_id`).
+    # Persist user_id at construction so it lands in the INSERT, not a deferrable post-INSERT
+    # UPDATE the bulk certificate_reissue task can lose. Same fix/shape as authority_id (#316);
+    # a NULL user_id later crashes reissue on creator=None. See CLOUDR-1948 / Netflix/lemur#5447.
+    from lemur.certificates.models import Certificate
+    from lemur.tests.factories import UserFactory
+
+    user = UserFactory()
+    session.commit()
+
+    cert = Certificate(body=SAN_CERT_STR, owner="joe@example.com", creator=user)
+
+    assert cert.user_id == user.id
+
+
+def test_certificate_init_allows_no_creator(session):
+    # Some paths construct without a creator (e.g. imports); user_id must stay None (no crash).
+    from lemur.certificates.models import Certificate
+
+    cert = Certificate(body=SAN_CERT_STR, owner="joe@example.com")
+
+    assert cert.user_id is None
+
+
 def test_get_or_increase_name(session, certificate):
     from lemur.certificates.models import get_or_increase_name
     from lemur.tests.factories import CertificateFactory

--- a/lemur/tests/test_pending_certificates.py
+++ b/lemur/tests/test_pending_certificates.py
@@ -15,9 +15,6 @@ from .vectors import (
 
 
 def test_pending_certificate_init_sets_authority_id_from_authority(session):
-    # ACME/async path goes through PendingCertificate; persist authority_id at construction
-    # (same fix as #316 for the sync Certificate) so it lands in the INSERT, not a deferrable
-    # post-INSERT UPDATE the reissue race can drop. See CLOUDR-1948 / Netflix/lemur#5447.
     from lemur.pending_certificates.models import PendingCertificate
     from lemur.tests.factories import AuthorityFactory
 
@@ -32,7 +29,6 @@ def test_pending_certificate_init_sets_authority_id_from_authority(session):
 
 
 def test_pending_certificate_init_sets_user_id_from_creator(session):
-    # Same construction-time fix for the creator FK on the ACME PendingCertificate path.
     from lemur.pending_certificates.models import PendingCertificate
     from lemur.tests.factories import UserFactory
 

--- a/lemur/tests/test_pending_certificates.py
+++ b/lemur/tests/test_pending_certificates.py
@@ -14,6 +14,38 @@ from .vectors import (
 )
 
 
+def test_pending_certificate_init_sets_authority_id_from_authority(session):
+    # ACME/async path goes through PendingCertificate; persist authority_id at construction
+    # (same fix as #316 for the sync Certificate) so it lands in the INSERT, not a deferrable
+    # post-INSERT UPDATE the reissue race can drop. See CLOUDR-1948 / Netflix/lemur#5447.
+    from lemur.pending_certificates.models import PendingCertificate
+    from lemur.tests.factories import AuthorityFactory
+
+    authority = AuthorityFactory()
+    session.commit()
+
+    pc = PendingCertificate(
+        csr=CSR_STR, authority=authority, owner="joe@example.com", name="pending-authfix-test"
+    )
+
+    assert pc.authority_id == authority.id
+
+
+def test_pending_certificate_init_sets_user_id_from_creator(session):
+    # Same construction-time fix for the creator FK on the ACME PendingCertificate path.
+    from lemur.pending_certificates.models import PendingCertificate
+    from lemur.tests.factories import UserFactory
+
+    user = UserFactory()
+    session.commit()
+
+    pc = PendingCertificate(
+        csr=CSR_STR, creator=user, owner="joe@example.com", name="pending-userfix-test"
+    )
+
+    assert pc.user_id == user.id
+
+
 def test_increment_attempt(pending_certificate):
     from lemur.pending_certificates.service import increment_attempt
 


### PR DESCRIPTION
Same fix as #316, extended to the creator/user_id foreign key and the ACME path.

create() and reissue_certificate build the cert with resolved creator and authority objects and wire them only as relationships (creator.certificates.append(cert), cert.authority = ...) just before commit, relying on SQLAlchemy to back-populate the user_id/authority_id columns at flush. Under the bulk certificate_reissue task that flush-time sync intermittently doesn't take, so the row lands with a NULL user_id (and, pre-#316, a NULL authority_id). A NULL user_id isn't cosmetic: the next reissue reads certificate.user as the new cert's creator, and when that is None create() crashes on creator=None after the cert has already been minted at the CA, orphaning it. Same relationship-to-FK flush race as [CLOUDR-1919](https://datadoghq.atlassian.net/browse/CLOUDR-1919), still open upstream at Netflix/lemur#5447.

The fix mirrors #316: set the FK columns directly from the resolved objects in the constructor so they are written by the INSERT instead of a deferrable post-INSERT UPDATE that the bulk task can drop. Certificate gets user_id (authority_id was already handled by #316). PendingCertificate gets both authority_id and user_id, since neither was hardened on the ACME path; this supersedes the draft #317.

Full test suite green in the workspace (822 passed), flake8 clean.

[CLOUDR-1948](https://datadoghq.atlassian.net/browse/CLOUDR-1948)


[CLOUDR-1919]: https://datadoghq.atlassian.net/browse/CLOUDR-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUDR-1948]: https://datadoghq.atlassian.net/browse/CLOUDR-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ